### PR TITLE
home page - split page components into separate subtemplates

### DIFF
--- a/gdexwebserver/templates/unity/alerts.html
+++ b/gdexwebserver/templates/unity/alerts.html
@@ -6,7 +6,7 @@
     {% if valid_date %}
 
      <div class="alert alert-{{ alert.level }} alert-dismissible fade show px-0" role="alert">
-        <div class="container-lg py-1 py-md-3">
+        <div class="container-lg py-1 py-md-2">
             <div class="d-flex">
                 <div>
                     {% if alert.level == 'info' %}

--- a/gdexwebserver/templates/unity/header_decs.html
+++ b/gdexwebserver/templates/unity/header_decs.html
@@ -4,114 +4,17 @@
     <nav class="navbar navbar-expand-md navbar-light align-items-start py-0">
         <div class="container-fluid px-0">
             <div class="row gx-0 flex-grow-1">
-                <div class="col-12">
-                    <div class="container-lg">
-                        <div class="row gx-0 py-md-1">
-                            <div class="col col-md-8 py-md-1">
-                                <div class="d-flex">
-                                    <div class="pe-1 my-1 my-md-0 nsf-logo align-self-center">
-                                        <a href="https://nsf.gov" title="U.S. NSF Home">
-                                            {% include "unity/picture_wagtail_media.html" with image="NSF_Official_logo" alt="NSF Logo" %}
-                                            <span class="sr-only">NCAR</span>
-                                        </a>
-                                    </div>
-                                    <div class="ps-2 my-1 py-md-0 align-self-center ncar-logo">
-                                        <div class="mb-0 small-ncar-logo">
-                                            <a href="/">
-                                                {% include "unity/picture_wagtail_media.html" with image="logo-ncar" alt="NSF NCAR" %}
-                                            </a>
-                                        </div>
-                                    </div>
-                                    <div class="ms-auto px-0 py-md-0 d-md-none justify-content-end mobile-toggler">
-                                        <button aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Mobile Menu" class="navbar-toggler collapsed btn border-start" data-bs-target="#navbarSupportedContent1,#navbarSupportedContent2" data-bs-toggle="collapse" id="menuIcon" type="button"></button>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="utility-menu col collapse d-none d-md-flex justify-content-end align-items-center pe-0">
-                                <div class="px-2">
-                                    <a href="mailto:rdahelp@ucar.edu">Contact Us</a>
-                                </div>
-                                {% if 'duser' in request.COOKIES %}
-                                    <div class="px-2 border-start">
-                                        <a href="/dashboard/">User Dashboard</a>
-                                    </div>
-                                    <div class="px-2 border-start">
-                                      <form method="post" action="{% url 'account_logout' %}">
-                                        {% csrf_token %}
-                                        {% if redirect_field_value %}
-                                        <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
-                                        {% endif %}
-                                        <button type="submit" 
-                                                class="" 
-                                                style="color:rgb(26,101,143);font-family:'Poppins','sans-serif';font-size:14px;font-weight:600;background:none;">
-                                           Sign Out
-                                        </button>
-                                      </form>
-                                    </div>
-                                {% else %}
-                                <div class="ps-2">
-                                    <a href="/accounts/login/?return={{ request.path }}" class="btn btn-pill btn-primary px-2 py-1 border-1" aria-label="Sign In">Sign In</a>
-                                </div>
-                               {% endif %}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col-12 navbar-wrapper border-top">
-                    <div class="container-lg collapse navbar-collapse" id="navbarSupportedContent1">
-                        <div class="site-name mx-3 mx-md-0 my-2">
-                            <a href="/">Geoscience Data Exchange</a>
-                        </div>
+                {% block header_top %}
+                {% include "unity/header_top.html" %}
+                {% endblock header_top %}
 
-                        {% comment %}
-                           Render main navigation menu
-                        {% endcomment %}
-                        {% main_menu template="menus/main_menu.html" %}
+                {% block header_navigation_bar %}
+                {% include "unity/header_nav_bar.html" %}
+                {% endblock header_navigation_bar %}
 
-                        <form class="utility-menu d-flex ms-2" action="/dssearch/">
-                            <label class="sr-only" for="siteSearch">Search</label>
-                            <input aria-label="Search" class="form-control" id="siteSearch" type="search" name="words" placeholder="Search">
-                            <button aria-label="Search" class="text-white bg-org-dark" type="submit" >Search GDEX</button>
-                        </form>
-
-                    </div>
-                </div>
-
-                {% comment %}
-                   Mobile utility menu
-                {% endcomment %}
-                <div class="col-12 mobile-utility-menu px-2 d-md-none">
-                    <div class="collapse navbar-collapse justify-content-end" id="navbarSupportedContent2">
-                        <div class="py-2 contact">
-                            <div>
-                                <a href="/contact-us/">Contact Us</a>
-                            </div>
-                        {% if 'duser' in request.COOKIES %}
-                            <div class="py-2">
-                                <a href="/ajax/#!cgi-bin/dashboard">User Dashboard</a>
-                            </div>
-                            <div class="py-2">
-                              <form method="post" action="{% url 'account_logout' %}">
-                                {% csrf_token %}
-                                {% if redirect_field_value %}
-                                <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
-                                {% endif %}
-                                  <button type="submit" 
-                                          class="" 
-                                          style="color:rgb(26,101,143);font-family:'Poppins','sans-serif';font-size:14px;font-weight:600;background:none;">
-                                     Sign Out
-                                  </button>
-                              </form>
-                            </div>
-                        {% else %}
-                            <div class="d-flex py-2">
-                                <a href="/accounts/login" class="btn btn-primary">Sign In</a>
-                            </div>
-                        {% endif %}
-                        </div>
-                    </div>
-                </div>
-
+                {% block header_mobile_login %}
+                {% include "unity/header_mobile_login.html" %}
+                {% endblock header_mobile_login %}
             </div>
         </div>
     </nav>

--- a/gdexwebserver/templates/unity/header_decs.html
+++ b/gdexwebserver/templates/unity/header_decs.html
@@ -1,6 +1,6 @@
 {% load decs_tags menu_tags %}
 
-<header class="sticky-top">
+<header>
     <nav class="navbar navbar-expand-md navbar-light align-items-start py-0">
         <div class="container-fluid px-0">
             <div class="row gx-0 flex-grow-1">

--- a/gdexwebserver/templates/unity/header_login.html
+++ b/gdexwebserver/templates/unity/header_login.html
@@ -1,0 +1,26 @@
+<div class="utility-menu col collapse d-none d-md-flex justify-content-end align-items-center pe-0">
+    <div class="px-2">
+        <a href="mailto:rdahelp@ucar.edu">Contact Us</a>
+    </div>
+    {% if 'duser' in request.COOKIES %}
+        <div class="px-2 border-start">
+            <a href="/dashboard/">User Dashboard</a>
+        </div>
+        <div class="px-2 border-start">
+            <form method="post" action="{% url 'account_logout' %}">
+                {% csrf_token %}
+                {% if redirect_field_value %}
+                    <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
+                {% endif %}
+                <button type="submit" class="" 
+                        style="color:rgb(26,101,143);font-family:'Poppins','sans-serif';font-size:14px;font-weight:600;background:none;">
+                        Sign Out
+                </button>
+            </form>
+        </div>
+    {% else %}
+        <div class="ps-2">
+            <a href="/accounts/login/?return={{ request.path }}" class="btn btn-pill btn-primary px-2 py-1 border-1" aria-label="Sign In">Sign In</a>
+        </div>
+    {% endif %}
+</div>

--- a/gdexwebserver/templates/unity/header_mobile_login.html
+++ b/gdexwebserver/templates/unity/header_mobile_login.html
@@ -6,7 +6,7 @@
             </div>
             {% if 'duser' in request.COOKIES %}
                 <div class="py-2">
-                    <a href="/ajax/#!cgi-bin/dashboard">User Dashboard</a>
+                    <a href="/dashboard/">User Dashboard</a>
                 </div>
                 <div class="py-2">
                     <form method="post" action="{% url 'account_logout' %}">

--- a/gdexwebserver/templates/unity/header_mobile_login.html
+++ b/gdexwebserver/templates/unity/header_mobile_login.html
@@ -1,0 +1,29 @@
+<div class="col-12 mobile-utility-menu px-2 d-md-none">
+    <div class="collapse navbar-collapse justify-content-end" id="navbarSupportedContent2">
+        <div class="py-2 contact">
+            <div>
+                <a href="/contact-us/">Contact Us</a>
+            </div>
+            {% if 'duser' in request.COOKIES %}
+                <div class="py-2">
+                    <a href="/ajax/#!cgi-bin/dashboard">User Dashboard</a>
+                </div>
+                <div class="py-2">
+                    <form method="post" action="{% url 'account_logout' %}">
+                        {% csrf_token %}
+                        {% if redirect_field_value %}
+                            <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
+                        {% endif %}
+                        <button type="submit" class="" style="color:rgb(26,101,143);font-family:'Poppins','sans-serif';font-size:14px;font-weight:600;background:none;">
+                            Sign Out
+                        </button>
+                    </form>
+                </div>
+            {% else %}
+                <div class="d-flex py-2">
+                    <a href="/accounts/login" class="btn btn-primary">Sign In</a>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+</div>

--- a/gdexwebserver/templates/unity/header_nav_bar.html
+++ b/gdexwebserver/templates/unity/header_nav_bar.html
@@ -1,0 +1,11 @@
+{% load decs_tags menu_tags %}
+
+<div class="col-12 navbar-wrapper border-top">
+    <div class="container-lg collapse navbar-collapse" id="navbarSupportedContent1">
+        <div class="site-name mx-3 mx-md-0 my-2">
+            <a href="/">Geoscience Data Exchange</a>
+        </div>
+        {% main_menu template="menus/main_menu.html" %}
+        {% include "unity/header_search.html" %}
+    </div>
+</div>

--- a/gdexwebserver/templates/unity/header_ncar_logo.html
+++ b/gdexwebserver/templates/unity/header_ncar_logo.html
@@ -1,0 +1,20 @@
+<div class="col col-md-8 py-md-1">
+<div class="d-flex">
+    <div class="pe-1 my-1 my-md-0 nsf-logo align-self-center">
+        <a href="https://nsf.gov" title="U.S. NSF Home">
+            {% include "unity/picture_wagtail_media.html" with image="NSF_Official_logo" alt="NSF Logo" %}
+            <span class="sr-only">NCAR</span>
+        </a>
+    </div>
+    <div class="ps-2 my-1 py-md-0 align-self-center ncar-logo">
+        <div class="mb-0 small-ncar-logo">
+            <a href="/">
+                {% include "unity/picture_wagtail_media.html" with image="logo-ncar" alt="NSF NCAR" %}
+            </a>
+        </div>
+    </div>
+    <div class="ms-auto px-0 py-md-0 d-md-none justify-content-end mobile-toggler">
+        <button aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Mobile Menu" class="navbar-toggler collapsed btn border-start" data-bs-target="#navbarSupportedContent1,#navbarSupportedContent2" data-bs-toggle="collapse" id="menuIcon" type="button"></button>
+    </div>
+</div>
+</div>

--- a/gdexwebserver/templates/unity/header_search.html
+++ b/gdexwebserver/templates/unity/header_search.html
@@ -1,0 +1,5 @@
+<form id="header-search-form" class="utility-menu d-flex ms-2" name="header_search_form" action="/gsearch/dataset-search/">
+    <label class="sr-only" for="siteSearch">Search</label>
+    <input class="form-control" id="siteSearch" type="text" autocomplete="off" data-provide="typeahead" name="q" placeholder="Search" aria-label="Search" value="">
+    <button aria-label="Search" class="text-white bg-org-dark" type="submit" >Search RDA</button>
+</form>

--- a/gdexwebserver/templates/unity/header_top.html
+++ b/gdexwebserver/templates/unity/header_top.html
@@ -1,0 +1,14 @@
+<div class="col-12">
+    <div class="container-lg">
+        <div class="row gx-0 py-md-1">
+                {% block header_ncar_logo %}
+                {% include "unity/header_ncar_logo.html" %}
+                {% endblock header_ncar_logo %}
+
+                {% block header_login %}
+                {% include "unity/header_login.html" %}
+                {% endblock header_login %}
+
+        </div>
+    </div>
+</div>

--- a/home/templates/home/home_grid_cards.html
+++ b/home/templates/home/home_grid_cards.html
@@ -1,0 +1,50 @@
+<div class="component featured-work container-lg pt-md-4">
+    <div class="row gx-0 justify-content-center">
+        <div class="col-10 primary">
+            <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-2 g-md-4">
+                <div class="col">
+                    <div class="card h-100">
+                        <div class="card-body">
+                            <h3 class="card-title text-center"><a href="/gsearch/dataset-search/" class="text-white">{{ page.card_1_title }}</a></h3>
+                            <div class="icon py-2 text-center">
+                                <i class="fas fa-{{ page.card_1_icon_name }} fa-2x"></i>
+                            </div>
+                            <p class="card-text text-center">{{ page.card_1_text|richtext }}</p>
+                        </div>
+                        <div class="card-footer text-center">
+                            <a href="{{ page.card_1_footer_page.url }}" class="btn btn-outline-light">{{ page.card_1_footer_text }}</a>
+                        </div>
+                    </div>
+                </div>
+                <div class="col">
+                    <div class="card h-100">
+                        <div class="card-body">
+                            <h3 class="card-title text-center"><a href="{{ page.card_2_footer_page.url }}" class="text-white">{{ page.card_2_title }}</a></h3>
+                            <div class="icon py-2 text-center">
+                                <i class="fas fa-{{ page.card_2_icon_name }} fa-2x"></i>
+                            </div>
+                            <p class="card-text text-center">{{ page.card_2_text|richtext }}</p>
+                        </div>
+                        <div class="card-footer text-center">
+                            <a href="{{ page.card_2_footer_page.url }}" class="btn btn-outline-light">{{ page.card_2_footer_text }}</a>
+                        </div>
+                    </div>
+                </div>
+                <div class="col">
+                    <div class="card h-100">
+                        <div class="card-body">
+                            <h3 class="card-title text-center"><a href="{{ page.card_3_footer_page.url }}" class="text-white">{{ page.card_3_title }}</a></h3>
+                            <div class="icon py-2 text-center">
+                                <i class="fas fa-{{ page.card_3_icon_name }} fa-2x"></i>
+                            </div>
+                            <p class="card-text text-center">{{ page.card_3_text|richtext }}</p>
+                        </div>
+                        <div class="card-footer text-center">
+                            <a href="{{ page.card_3_footer_page.url }}" class="btn btn-outline-light">{{ page.card_3_footer_text }}</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/home/templates/home/home_grid_cards.html
+++ b/home/templates/home/home_grid_cards.html
@@ -1,3 +1,5 @@
+{% load wagtailcore_tags %}
+
 <div class="component featured-work container-lg pt-md-4">
     <div class="row gx-0 justify-content-center">
         <div class="col-10 primary">

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -1,95 +1,28 @@
 {% extends "base.html" %}
-
 {% load wagtailcore_tags %}
 
 {% block content %}
-
-        <div class="d-grid d-print-flex">
-            <article class="main-content-wrapper">
-
-                {% comment %}welcome message{% endcomment %}
-                <div class="row justify-content-center">
-                    <div class="col-lg-10">
-                        <div class="text-center">
-                            <h3 class="display-6 text-black mb-2">{{ page.tagline|richtext }}</h3>
-                            <p class="text-black-50">{{ page.welcome|richtext }}</p>
-                        </div>
-                    </div>
+<div class="d-grid d-print-flex">
+    <article class="main-content-wrapper">
+        {% block welcome_message %}
+        <div class="row justify-content-center">
+            <div class="col-lg-10">
+                <div class="text-center">
+                    <h3 class="display-6 text-black mb-2">{{ page.tagline|richtext }}</h3>
+                    <p class="text-black-50">{{ page.welcome|richtext }}</p>
                 </div>
-
-{% comment %}search bar {% endcomment %} 
-    <div class="component featured-work container-lg">
-    <div class="row gx-0 pt-md-4 justify-content-center">
-        <div class="col-8 primary text-center">
-        <div class="card">
-            <div class="card-body">
-                <h3 class="card-title mb-md-2">{{ page.search_box_title }}</h3>
-                <form class="d-flex" action="/dssearch/">
-                    <input class="form-control" id="dataSearch" name="words" type="search" aria-label="Search" placeholder="{{ page.search_box_placeholder }}">
-                    <button class="btn btn-primary" type="submit" aria-label="Search"><i class="fas fa-search"></i></button>
-                </form>
             </div>
         </div>
-        </div>
-    </div>
-    </div>
-{% comment %} end search bar {% endcomment %} 
+        {% endblock %}
 
-                {% comment %}grid cards{% endcomment %}
-                <div class="component featured-work container-lg pt-md-4">
-                    <div class="row gx-0 justify-content-center">
-                        <div class="col-10 primary">
-                            <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-2 g-md-4">
-                                <div class="col">
-                                    <div class="card h-100">
-                                        <div class="card-body">
-                                            <h3 class="card-title text-center"><a href="/gsearch/dataset-search/" class="text-white">{{ page.card_1_title }}</a></h3>
-                                            <div class="icon py-2 text-center">
-                                                <i class="fas fa-{{ page.card_1_icon_name }} fa-2x"></i>
-                                            </div>
-                                            <p class="card-text text-center">{{ page.card_1_text|richtext }}</p>
-                                        </div>
-                                        <div class="card-footer text-center">
-                                            <a href="{{ page.card_1_footer_page.url }}" class="btn btn-outline-light">{{ page.card_1_footer_text }}</a>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col">
-                                    <div class="card h-100">
-                                        <div class="card-body">
-                                            <h3 class="card-title text-center"><a href="{{ page.card_2_footer_page.url }}" class="text-white">{{ page.card_2_title }}</a></h3>
-                                            <div class="icon py-2 text-center">
-                                                <i class="fas fa-{{ page.card_2_icon_name }} fa-2x"></i>
-                                            </div>
-                                            <p class="card-text text-center">{{ page.card_2_text|richtext }}</p>
-                                        </div>
-                                        <div class="card-footer text-center">
-                                            <a href="{{ page.card_2_footer_page.url }}" class="btn btn-outline-light">{{ page.card_2_footer_text }}</a>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col">
-                                    <div class="card h-100">
-                                        <div class="card-body">
-                                            <h3 class="card-title text-center"><a href="{{ page.card_3_footer_page.url }}" class="text-white">{{ page.card_3_title }}</a></h3>
-                                            <div class="icon py-2 text-center">
-                                                <i class="fas fa-{{ page.card_3_icon_name }} fa-2x"></i>
-                                            </div>
-                                            <p class="card-text text-center">{{ page.card_3_text|richtext }}</p>
-                                        </div>
-                                        <div class="card-footer text-center">
-                                            <a href="{{ page.card_3_footer_page.url }}" class="btn btn-outline-light">{{ page.card_3_footer_text }}</a>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+        {% block home_search_bar %}
+        {% include 'home/home_search_bar.html' %}
+        {% endblock %}
 
-            </article>
-        </div>
-
-    {% include_block page.card_1 %}
-
+        {% block grid_cards %}
+        {% include 'home/home_grid_cards.html' %}
+        {% endblock %}
+    </article>
+</div>
+{% include_block page.card_1 %}
 {% endblock %}

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -43,7 +43,7 @@
                                 <div class="col">
                                     <div class="card h-100">
                                         <div class="card-body">
-                                            <h3 class="card-title text-center"><a href="{{ page.card_1_footer_page.url }}" class="text-white">{{ page.card_1_title }}</a></h3>
+                                            <h3 class="card-title text-center"><a href="/gsearch/dataset-search/" class="text-white">{{ page.card_1_title }}</a></h3>
                                             <div class="icon py-2 text-center">
                                                 <i class="fas fa-{{ page.card_1_icon_name }} fa-2x"></i>
                                             </div>

--- a/home/templates/home/home_search_bar.html
+++ b/home/templates/home/home_search_bar.html
@@ -4,7 +4,7 @@
             <div class="card">
                 <div class="card-body">
                     <h3 class="card-title mb-md-2">{{ page.search_box_title }}</h3>
-                    <form id="search-form" class="d-flex" name="search_form" action="{% url 'search' globus_portal_framework.index %}">
+                    <form id="search-form" class="d-flex" name="search_form" action="/gsearch/dataset-search/">
                         <input class="form-control" type="text" id="search-input" autocomplete="off" data-provide="typeahead" name="q" placeholder="{{ page.search_box_placeholder }}" value="">
                         <button class="btn btn-primary" type="submit" aria-label="Search"><i class="fas fa-search"></i></button>
                     </form>

--- a/home/templates/home/home_search_bar.html
+++ b/home/templates/home/home_search_bar.html
@@ -1,0 +1,15 @@
+<div class="component featured-work container-lg">
+    <div class="row gx-0 pt-md-4 justify-content-center">
+        <div class="col-8 primary text-center">
+            <div class="card">
+                <div class="card-body">
+                    <h3 class="card-title mb-md-2">{{ page.search_box_title }}</h3>
+                    <form id="search-form" class="d-flex" name="search_form" action="{% url 'search' globus_portal_framework.index %}">
+                        <input class="form-control" type="text" id="search-input" autocomplete="off" data-provide="typeahead" name="q" placeholder="{{ page.search_box_placeholder }}" value="">
+                        <button class="btn btn-primary" type="submit" aria-label="Search"><i class="fas fa-search"></i></button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
It has been difficult to read through all the nested `<div>` tags and make changes to the header and home page templates.  This splits each component into separate subtemplates and makes it easier to find and update the different components of the home page (top header, login, navigation bar, search bar, grid cards, etc.).

This pull request also changes the search bar on the home page and navigation bar to use Globus Search.