### PR TITLE
add favicon package for gdex icon

### DIFF
--- a/gdexwebserver/templates/unity/icons.html
+++ b/gdexwebserver/templates/unity/icons.html
@@ -1,9 +1,7 @@
-        <link rel="apple-touch-icon" sizes="180x180" href="/media/images/favicon/apple-touch-icon.png">
-        <link rel="icon" type="image/png" sizes="32x32" href="/media/images/favicon/favicon-32x32.png">
-        <link rel="icon" type="image/png" sizes="16x16" href="/media/images/favicon/favicon-16x16.png">
-        <link rel="manifest" href="/media/images/favicon/site.webmanifest">
-        <link rel="mask-icon" href="/media/images/favicon/safari-pinned-tab.svg" color="#007fa3">
-        <link rel="shortcut icon" href="/media/images/favicon/favicon.ico">
-        <meta name="msapplication-TileColor" content="#00c1d5">
-        <meta name="msapplication-config" content="/media/images/favicon/browserconfig.xml">
-        <meta name="theme-color" content="#d9d9dc">
+<link rel="icon" type="image/png" href="/media/images/favicon/favicon-96x96.png" sizes="96x96" />
+<link rel="icon" type="image/svg+xml" href="/media/images/favicon/favicon.svg" />
+<link rel="shortcut icon" href="/media/images/favicon/favicon.ico" />
+<link rel="apple-touch-icon" sizes="180x180" href="/media/images/favicon/apple-touch-icon.png" />
+<link rel="manifest" href="/media/images/favicon/site.webmanifest" />
+<meta name="msapplication-TileColor" content="#00c1d5">
+<meta name="theme-color" content="#d9d9dc">


### PR DESCRIPTION
1. Icon package was generated at https://realfavicongenerator.net/ 

2. Download your favicon package.

3. Extract this package in <web site>/media/images/favicon/. If your site is http://www.example.com, you should be able to access a file named http://www.example.com/media/images/favicon/favicon.ico.

4. Insert the following code in the <head> section of your pages:
```
<link rel="icon" type="image/png" href="/media/images/favicon/favicon-96x96.png" sizes="96x96" />
<link rel="icon" type="image/svg+xml" href="/media/images/favicon/favicon.svg" />
<link rel="shortcut icon" href="/media/images/favicon/favicon.ico" />
<link rel="apple-touch-icon" sizes="180x180" href="/media/images/favicon/apple-touch-icon.png" />
<link rel="manifest" href="/media/images/favicon/site.webmanifest" />
```