### PR TITLE
dataaccess matrix - fix url for glade/HPC links

### DIFF
--- a/dataaccess/templates/dataaccess/matrix.html
+++ b/dataaccess/templates/dataaccess/matrix.html
@@ -131,7 +131,7 @@
     {% if matrix.columns.glade %}
     <div style="grid-row: 3"></div>
     <div class="c-fil o-blk tx-c" style="grid-row: 3">
-        <a href="javascript:void(0)" onclick="$.get('{{ matrix.union_urls.glade }}/?fl=glade', replace_ds_content)">NCAR HPC<br>Data Access</a>
+        <a href="javascript:void(0)" onclick="$.get('{{ matrix.union_urls.glade }}?fl=glade', replace_ds_content)">NCAR HPC<br>Data Access</a>
     </div>
     {% endif %}
 
@@ -193,7 +193,7 @@
             {% if matrix.columns.glade %}
             <div style="grid-row: {{ row }}"></div>
             <div class="c-fil o-blk tx-c" style="grid-row: {{ row }}">
-                <a href="javascript:void(0)" onclick="$.get('{{ matrix.union_urls.glade }}/{% if group.index %}{{ group.index }}/{% endif %}?fl=glade', replace_ds_content)">NCAR HPC<br>Data Access</a>
+                <a href="javascript:void(0)" onclick="$.get('{{ matrix.union_urls.glade }}{% if group.index %}{{ group.index }}/{% endif %}?fl=glade', replace_ds_content)">NCAR HPC<br>Data Access</a>
             </div>
             {% endif %}
 	    {% else %} {% comment %} If ARCO groups: {% endcomment %}

--- a/dataaccess/templates/dataaccess/matrix.html
+++ b/dataaccess/templates/dataaccess/matrix.html
@@ -131,7 +131,7 @@
     {% if matrix.columns.glade %}
     <div style="grid-row: 3"></div>
     <div class="c-fil o-blk tx-c" style="grid-row: 3">
-        <a href="javascript:void(0)" onclick="$.get('{{ matrix.union_urls.glade }}', replace_ds_content)">NCAR HPC<br>Data Access</a>
+        <a href="javascript:void(0)" onclick="$.get('{{ matrix.union_urls.glade }}/?fl=glade', replace_ds_content)">NCAR HPC<br>Data Access</a>
     </div>
     {% endif %}
 

--- a/gdexwebserver/settings/base.py
+++ b/gdexwebserver/settings/base.py
@@ -357,13 +357,15 @@ for app in INSTALLED_APPS:
 ########################################################################
 
 GDEX_BASE_PATH = '/glade/campaign/collections/gdex/'
+GDEX_SHORT_PATH = '/gdex/'
+
 RDA_BASE_PATH = GDEX_BASE_PATH
 
-RDA_DATA_PATH = os.path.join(RDA_BASE_PATH, 'data/')
-RDA_REQUEST_PATH = os.path.join(RDA_BASE_PATH, 'transfer/')
-RDA_REQUEST_HOME = os.path.join(RDA_BASE_PATH, 'transfer/dsrqst/')
-RDA_CANONICAL_DATA_PATH = os.path.join(RDA_BASE_PATH, 'data/')
-RDA_CANONICAL_REQUEST_PATH = os.path.join(RDA_BASE_PATH, 'transfer/')
+RDA_DATA_PATH = os.path.join(GDEX_BASE_PATH, 'data/')
+RDA_REQUEST_PATH = os.path.join(GDEX_BASE_PATH, 'transfer/')
+RDA_REQUEST_HOME = os.path.join(GDEX_BASE_PATH, 'transfer/dsrqst/')
+RDA_CANONICAL_DATA_PATH = os.path.join(GDEX_SHORT_PATH, 'data/')
+RDA_CANONICAL_REQUEST_PATH = os.path.join(GDEX_SHORT_PATH, 'transfer/')
 
 GDEX_DATA_PATH = os.path.join(GDEX_BASE_PATH, 'data')
 GDEX_REQUEST_PATH = os.path.join(GDEX_BASE_PATH, 'transfer')


### PR DESCRIPTION
1. Fix the URL to glade/HPC file lists for datasets not supported by 'Faceted Browse'.
2. Change the glade access paths to use the symlink `/gdex/data`