### PR TITLE
Revert cert troubleshooting changes

### DIFF
--- a/app-chart/templates/ingress-old-esg.yaml
+++ b/app-chart/templates/ingress-old-esg.yaml
@@ -8,10 +8,9 @@ metadata:
     group: {{ .Values.webapp.group }}
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt"
-    acme.cert-manager.io/http01-ingress-class: "nginx-internal"
-#    nginx.ingress.kubernetes.io/permanent-redirect: "https://esg.k8s.ucar.edu"
+    nginx.ingress.kubernetes.io/permanent-redirect: "https://esg.k8s.ucar.edu"
 spec:
-  ingressClassName: nginx-internal
+  ingressClassName: nginx-external
   tls:
     - hosts:
       - earthsystemgrid.org


### PR DESCRIPTION
 ESG redirects to gdex and is available externally. This at least works for the UI for right now. Programmatic requests to earthsystemgrid.org will get an SSL error until we get a valid cert issued. 