### PR TITLE
remove redirect for cert issue

### DIFF
--- a/app-chart/templates/ingress-old-esg.yaml
+++ b/app-chart/templates/ingress-old-esg.yaml
@@ -8,7 +8,7 @@ metadata:
     group: {{ .Values.webapp.group }}
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt"
-    nginx.ingress.kubernetes.io/permanent-redirect: "https://esg.k8s.ucar.edu"
+#    nginx.ingress.kubernetes.io/permanent-redirect: "https://esg.k8s.ucar.edu"
 spec:
   ingressClassName: nginx-external
   tls:


### PR DESCRIPTION
The lets encrypt certificate requests are getting redirected. In order to get a valid cert we need to remove the redirect until the cert is issued and then we can add it back in