### PR TITLE
Fix links for files served from boreas

### DIFF
--- a/api/common.py
+++ b/api/common.py
@@ -1052,8 +1052,8 @@ def create_filelist_table(dsid, gindex, page=0, filter_wfile=None):
     for _file in files:
         file_url = get_webfile_url(dsid, _file['wfile'], base_url, origin_path=origin_path, locflag=locflag)
         data_path = os.path.join('/',dsid,_file['wfile'])
-        if _file['locflag'] == 'O':
-            data_path = os.path.join('/OS',dsid,_file['wfile'])
+        #if _file['locflag'] == 'O':
+        #    data_path = os.path.join('/OS',dsid,_file['wfile'])
         filename = {
             'is_file' : True,
             'name' : long_name('wfile'),


### PR DESCRIPTION
This pull request makes a small change to the logic for setting the `data_path` variable in the `create_filelist_table` function. The code that updated `data_path` based on the value of `_file['locflag']` has been commented out, so `data_path` will now always be set to the default path.

* Commented out the conditional logic that changed `data_path` when `_file['locflag']` was `'O'` in `api/common.py`.