### PR TITLE
fix url for arco files with '-http'

### DIFF
--- a/datasets/templates/datasets/filelist-arco-button.html
+++ b/datasets/templates/datasets/filelist-arco-button.html
@@ -1,20 +1,25 @@
 {% with data.is_glade as is_glade %}
-{% with settings.RDA_STRATUS_BASE_URL as rda_base_url %}
+{% with settings.RDA_STRATUS_BASE_URL as os_base_url %}
+{% with settings.RDA_DATA_BASE_URL as rda_base_url %}
 {% with settings.GDEX_CANONICAL_DATA_PATH as gdex_base_path %}
 {% load wagtailcore_tags static decs_tags home_tags custom_tags %}
     <button class='btn btn-primary px-2 py-1 float-end rounded' 
             type='button' 
             style='transition:all 0.2s ease; font-size:1rem;' 
             onclick="copyFullLink(this, 
-                    {% if is_glade %}
-                    '/{% get_copy_path gdex_base_path data.dsid col.webpath %}',
+                {% if is_glade and data.locflag != 'O' %}
+                    '{% get_copy_path gdex_base_path data.dsid col.webpath %}',
                     '{% get_copy_path_title gdex_base_path data.dsid col.webpath %}'
-                    {% else %}
+                {% elif data.locflag == 'O' %}
+                    '{% get_copy_path os_base_url data.dsid col.webpath %}',
+                    '{% get_copy_path_title os_base_url data.dsid col.webpath %}'
+                {% else %}
                     '{% get_copy_path rda_base_url data.dsid col.webpath %}',
                     '{% get_copy_path_title rda_base_url data.dsid col.webpath %}'
-                    {% endif %}
-                    )">
-        <i class="fa-solid fa-copy pe-1"></i>{% get_copy_path_title rda_base_url data.dsid col.webpath %}
+                {% endif %}
+            )">
+        <i class="fa-solid fa-copy pe-1"></i>
+        {% get_copy_path_title rda_base_url data.dsid col.webpath %}
     </button>
 {% endwith %}
 {% endwith %}

--- a/home/templatetags/custom_tags.py
+++ b/home/templatetags/custom_tags.py
@@ -160,7 +160,7 @@ def show_arco_catalogs(context):
                     if '-posix' in url:
                         url = os.path.join(settings.GDEX_SHORT_PATH, 'data', file_info['file_path'].strip('/'))
                     elif '-http' in url:
-                        url = 'https://' + settings.GLOBUS_DATA_DOMAIN.strip('/') + file_info['file_path']
+                        url = url
                     elif '-osdf' not in url: # Some assets don't have posix
                         url = os.path.join(settings.GDEX_SHORT_PATH, 'data', file_info['file_path'].strip('/'))
                     file_info['file_url'] = url

--- a/home/templatetags/custom_tags.py
+++ b/home/templatetags/custom_tags.py
@@ -80,8 +80,9 @@ def get_dsid_from_url(url):
 
 @register.filter
 def make_glade_URL(uri):
-    if (uri.find('/',0,1) != -1):
-        uri = uri.replace('/','',1)
+    """ Convert file URL path to a posix path for NCAR HPC access """
+    if uri.startswith('/'):
+        uri = uri.lstrip('/')
     url = os.path.join(settings.RDA_CANONICAL_DATA_PATH, uri)
     if '/OS/' in url:
         return re.sub('.*/OS/', settings.NCAR_STRATUS_URL, url)

--- a/home/templatetags/decs_tags.py
+++ b/home/templatetags/decs_tags.py
@@ -3,6 +3,7 @@ import psycopg2
 from django.conf import settings
 from pathlib import Path
 from urllib.parse import urlparse
+import os
 
 register = template.Library()
 
@@ -89,7 +90,7 @@ def getORCID(extra_data_dict):
 @register.simple_tag
 def get_copy_path(basepath, dsid, webpath):
     """Given a catalog/kerchunk relative path, return full URL/PATH"""
-    return basepath.strip('/') + '/' + dsid + '/' + webpath
+    return os.path.join(basepath.strip('/'), dsid, webpath.strip('/'))
 
 @register.simple_tag
 def get_copy_path_title(basepath, dsid, webpath):


### PR DESCRIPTION
This pull request updates the logic for generating file access paths and URLs in both templates and custom template tags, aiming to improve consistency and correctness when constructing file links for different storage backends. The main changes focus on using `os.path.join` for path construction, refining conditional logic for button actions, and cleaning up unused code.

**Template and Path Construction Improvements:**

* Updated the button logic in `filelist-arco-button.html` to distinguish between different storage backends (`GLADE`, `OS`, and `RDA`) using more precise conditions and variable names, ensuring the correct path is generated for each case.
* Changed the implementation of `get_copy_path` in `decs_tags.py` to use `os.path.join` for safer and more reliable path concatenation, reducing the risk of malformed URLs or paths.
* Modified the `make_glade_URL` filter to use `lstrip('/')` for removing leading slashes and clarified its docstring, improving the conversion of file URLs for NCAR HPC access.

**Code Cleanliness and Consistency:**

* Added an `import os` statement to `decs_tags.py` to support the new path joining logic.
* Simplified the URL assignment logic in `show_arco_catalogs` by removing redundant string concatenation for HTTP URLs, ensuring the original URL is preserved.This pull request makes a small change to the URL handling logic in the `show_arco_catalogs` function. The update simplifies how URLs containing `-http` are processed by leaving them unchanged instead of reconstructing them.

* Simplified handling of URLs with `-http` by assigning the original value directly to `url` instead of rebuilding the URL string.