### PR TITLE
fix: add missing endwith tag in filelist-arco-button template

### DIFF
--- a/datasets/templates/datasets/filelist-arco-button.html
+++ b/datasets/templates/datasets/filelist-arco-button.html
@@ -24,3 +24,4 @@
 {% endwith %}
 {% endwith %}
 {% endwith %}
+{% endwith %}


### PR DESCRIPTION
This pull request makes a minor update to the `datasets/templates/datasets/filelist-arco-button.html` template. The change adds an additional `{% endwith %}` statement, which likely closes a previously opened `{% with %}` block to ensure proper template logic.