### PR TITLE
Minor changes to README and favicon readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,3 @@
 # GDEX Web Portal
 
 This project contains the Python Django framework supporting the [NSF NCAR Geoscience Data Exchange (GDEX)](https://gdex.ucar.edu) data portal.
-
-
-
-
-
-
-<<<<<<< HEAD
-=======
-
-
->>>>>>> 2618758 (new line)

--- a/gdexwebserver/static/img/app-favicons/gdex/README
+++ b/gdexwebserver/static/img/app-favicons/gdex/README
@@ -8,14 +8,19 @@
 
 2. Download your package
 
-3. Extract this package in <web site>/img/app-favicons/gdex/. If your site is http://www.example.com, you should be able to access a file named http://www.example.com/img/app-favicons/gdex/favicon.ico.
+3. Extract this package in /gdexwebserver/static/img/app-favicons/gdex/. This should create the following files in that directory:
+- apple-touch-icon.png
+- favicon-96x96.png
+- favicon.ico
+- favicon.svg
+- site.webmanifest
 
-4. Insert the following code in the <head> section of your pages:
+4. Insert the following code in /gdexwebserver/templates/unity/icons.html, replacing the existing code that references the old favicon files.  This should be placed after the line {% load static %} and before any other code in that file.  The code to insert is as follows:
 
-<link rel="icon" type="image/png" href="/img/app-favicons/gdex/favicon-96x96.png" sizes="96x96" />
-<link rel="icon" type="image/svg+xml" href="/img/app-favicons/gdex/favicon.svg" />
-<link rel="shortcut icon" href="/img/app-favicons/gdex/favicon.ico" />
-<link rel="apple-touch-icon" sizes="180x180" href="/img/app-favicons/gdex/apple-touch-icon.png" />
+<link rel="icon" type="image/png" href="{% static 'img/app-favicons/gdex/favicon-96x96.png' %}" sizes="96x96" />
+<link rel="icon" type="image/svg+xml" href="{% static 'img/app-favicons/gdex/favicon.svg' %}" />
+<link rel="shortcut icon" href="{% static 'img/app-favicons/gdex/favicon.ico' %}" />
+<link rel="apple-touch-icon" sizes="180x180" href="{% static 'img/app-favicons/gdex/apple-touch-icon.png' %}" />
 <meta name="apple-mobile-web-app-title" content="GDEX" />
-<link rel="manifest" href="/img/app-favicons/gdex/site.webmanifest" />
+<link rel="manifest" href="{% static 'img/app-favicons/gdex/site.webmanifest' %}" />
 

--- a/gdexwebserver/static/img/app-favicons/gdex/README
+++ b/gdexwebserver/static/img/app-favicons/gdex/README
@@ -1,21 +1,21 @@
-1. Go to https://realfavicongenerator.net and upload the standard (blue) GDEX icon (SVG or PNG format).  
+1. Go to https://realfavicongenerator.net and upload the standard (blue) GDEX icon (PNG format).  
 
 2. Configuration:
-- Dark icon: Select 'Use another icon' and choose the white GDEX icon.
-- Apple Touch Icon: Select 'Add a plain background and margins.  Set color to white (#ffffff) and set image size to largest setting.  Set App name = 'GDEX'
-- Web app manifest: set Name = 'NCAR GDEX' and Short name = 'GDEX'. Select 'Add a plain background and margins.  Set image size to largest setting. Set background and theme color to white (#ffffff).
-- Favicon path: set favicon path = /media/images/favicon/
+- Dark icon: Select 'Use another icon' and choose the white GDEX icon (PNG format).
+- Apple Touch Icon: Select 'Add a plain background and margins'.  Set color to white (#ffffff) and set image size to largest setting.  Set App name = 'GDEX'
+- Web app manifest: set Name = 'NCAR GDEX' and Short name = 'GDEX'. Select 'Add a plain background and margins'.  Set image size to largest setting. Set background and theme color to white (#ffffff).
+- Favicon path: set favicon path = /img/app-favicons/gdex/
 
 2. Download your package
 
-3. Extract this package in <web site>/media/images/favicon/. If your site is http://www.example.com, you should be able to access a file named http://www.example.com/media/images/favicon/favicon.ico.
+3. Extract this package in <web site>/img/app-favicons/gdex/. If your site is http://www.example.com, you should be able to access a file named http://www.example.com/img/app-favicons/gdex/favicon.ico.
 
 4. Insert the following code in the <head> section of your pages:
 
-<link rel="icon" type="image/png" href="/media/images/favicon/favicon-96x96.png" sizes="96x96" />
-<link rel="icon" type="image/svg+xml" href="/media/images/favicon/favicon.svg" />
-<link rel="shortcut icon" href="/media/images/favicon/favicon.ico" />
-<link rel="apple-touch-icon" sizes="180x180" href="/media/images/favicon/apple-touch-icon.png" />
+<link rel="icon" type="image/png" href="/img/app-favicons/gdex/favicon-96x96.png" sizes="96x96" />
+<link rel="icon" type="image/svg+xml" href="/img/app-favicons/gdex/favicon.svg" />
+<link rel="shortcut icon" href="/img/app-favicons/gdex/favicon.ico" />
+<link rel="apple-touch-icon" sizes="180x180" href="/img/app-favicons/gdex/apple-touch-icon.png" />
 <meta name="apple-mobile-web-app-title" content="GDEX" />
-<link rel="manifest" href="/media/images/favicon/site.webmanifest" />
+<link rel="manifest" href="/img/app-favicons/gdex/site.webmanifest" />
 


### PR DESCRIPTION
This pull request updates documentation related to favicon setup for the GDEX web portal, clarifying instructions and improving accuracy for both developers and maintainers. The changes mainly focus on updating the `README` files and favicon configuration instructions.

Favicon setup and documentation improvements:

* Updated `gdexwebserver/static/img/app-favicons/gdex/README` to clarify that only PNG format should be used for favicon generation and to specify the correct directory (`/gdexwebserver/static/img/app-favicons/gdex/`) for extracting favicon files, replacing previous references to `/media/images/favicon/`. Also provided explicit instructions for updating the Django template file (`/gdexwebserver/templates/unity/icons.html`) with the new favicon code.
* Modified favicon code snippets to use Django's `{% static %}` template tag for referencing favicon assets, ensuring proper static file handling within the web application.

General documentation cleanup:

* Removed merge conflict markers and extraneous lines from `README.md` to tidy up the project documentation.This pull request includes documentation updates to clarify favicon generation and usage for the GDEX web portal. The changes focus on correcting file format instructions, updating file paths, and improving configuration steps for favicon assets.

Favicon documentation improvements:

* Updated instructions in `gdexwebserver/static/img/app-favicons/gdex/README` to specify PNG format for favicon uploads and dark icon selection, replacing previous references to SVG.
* Changed favicon asset paths throughout the README from `/media/images/favicon/` to `/img/app-favicons/gdex/` to match the current directory structure.
* Improved configuration steps for Apple Touch Icon and web app manifest by clarifying background and margin settings, and corrected the location for extracting favicon packages.
* Updated example HTML code to reference the new favicon paths and ensure correct asset linking for all icon types.

General documentation cleanup:

* Removed extraneous merge conflict markers and blank lines from `README.md` for improved clarity.