### PR TITLE
fix: use Globus domains for ARCO catalogs

### DIFF
--- a/api/common.py
+++ b/api/common.py
@@ -1044,8 +1044,11 @@ def create_filelist_table(dsid, gindex, page=0, filter_wfile=None):
     locflag = get_dataset_location(dsid)
     origin_path = get_guest_collection_origin_path(dsid)
 
-    if gindex == "-1":
-        base_url = settings.GLOBUS_STRATUS_BASE_URL
+    if int(gindex) < 0:  # Use Globus HTTPS domains for ARCO datasets (gindex < 0)
+        if locflag == 'G':
+            base_url = settings.GLOBUS_DATA_BASE_URL
+        else:
+            base_url = settings.GLOBUS_STRATUS_BASE_URL
     else:
         base_url = get_webfile_base_url(dsid, files[0]['wfile'], locflag=locflag)
 

--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v22863948193
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v22878228582
     port: 8080
     requests:
       memory: 4Gi


### PR DESCRIPTION
This pull request makes a targeted improvement to the logic for selecting the base URL in the `create_filelist_table` function. The change ensures that for ARCO datasets (where `gindex` is less than 0), the correct Globus HTTPS domain is used based on the dataset location.

Dataset URL selection logic update:

* Updated the condition to check if `gindex` is less than 0, and added logic to select `settings.GLOBUS_DATA_BASE_URL` when the dataset location is `'G'`, otherwise use `settings.GLOBUS_STRATUS_BASE_URL`. This ensures ARCO datasets use the appropriate Globus HTTPS domain.