### PR TITLE
Fix duplicate dsid in arco urls

### DIFF
--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v22878228582
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v22885484452
     port: 8080
     requests:
       memory: 4Gi

--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v22885484452
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v22885622703
     port: 8080
     requests:
       memory: 4Gi

--- a/datasets/templates/datasets/filelist-arco-button.html
+++ b/datasets/templates/datasets/filelist-arco-button.html
@@ -1,3 +1,5 @@
+{% load custom_tags %}
+
 {% with data.is_glade as is_glade %}
 {% with settings.RDA_STRATUS_BASE_URL as os_base_url %}
 {% with settings.NCAR_STRATUS_URL as ncar_os_base_url %}
@@ -13,7 +15,7 @@
                         '{% get_copy_path gdex_base_path data.dsid col.webpath %}',
                         '{% get_copy_path_title gdex_base_path data.dsid col.webpath %}'
                     {% else %}
-                        '{% get_copy_path gdex_base_path data.dsid col.data_path %}',
+                        '{% with full_path=gdex_base_path|concat_paths:col.data_path %}{{ full_path }}{% endwith %}',
                         '{% get_copy_path_title gdex_base_path data.dsid col.data_path %}'
                     {% endif %}
                 {% elif is_glade and data.locflag == 'O' %}
@@ -21,7 +23,7 @@
                         '{% get_copy_path ncar_os_base_url data.dsid col.webpath %}',
                         '{% get_copy_path_title ncar_os_base_url data.dsid col.webpath %}'
                     {% else %}
-                        '{% get_copy_path ncar_os_base_url data.dsid col.data_path %}',
+                        '{% with full_path=ncar_os_base_url|concat_paths:col.data_path %}{{ full_path }}{% endwith %}',
                         '{% get_copy_path_title ncar_os_base_url data.dsid col.data_path %}'
                     {% endif %}
                 {% elif data.locflag == 'O' %}
@@ -29,7 +31,7 @@
                         '{% get_copy_path os_base_url data.dsid col.webpath %}',
                         '{% get_copy_path_title os_base_url data.dsid col.webpath %}'
                     {% else %}
-                        '{% get_copy_path os_base_url data.dsid col.data_path %}',
+                        '{% with full_path=os_base_url|concat_paths:col.data_path %}{{ full_path }}{% endwith %}',
                         '{% get_copy_path_title os_base_url data.dsid col.data_path %}'
                     {% endif %}
                 {% else %}
@@ -37,7 +39,7 @@
                         '{% get_copy_path gdex_base_url data.dsid col.webpath %}',
                         '{% get_copy_path_title gdex_base_url data.dsid col.webpath %}'
                     {% else %}
-                        '{% get_copy_path gdex_base_url data.dsid col.data_path %}',
+                        '{% with full_path=gdex_base_url|concat_paths:col.data_path %}{{ full_path }}{% endwith %}',
                         '{% get_copy_path_title gdex_base_url data.dsid col.data_path %}'
                     {% endif %}
                 {% endif %}

--- a/datasets/templates/datasets/filelist-table.html
+++ b/datasets/templates/datasets/filelist-table.html
@@ -39,7 +39,7 @@
 
                         {% if data.is_glade and col.is_file %}
                             {% if data.locflag == 'O' %}
-                                {{ col.data_path|make_local_os_URL }}
+                                {{ col.url|make_local_os_URL }}
                             {% else %}
                                 {{ col.data_path|make_glade_URL }}
                             {% endif %}

--- a/home/templatetags/custom_tags.py
+++ b/home/templatetags/custom_tags.py
@@ -89,10 +89,15 @@ def make_glade_URL(uri):
     return url
 
 @register.filter
-def make_local_os_URL(uri):
-    """ Convert file URL path to a local OS URL for NCAR users with OS access """
-    url = os.path.join(settings.NCAR_STRATUS_URL, uri.lstrip('/'))
+def make_local_os_URL(url):
+    """ Convert file URL to a local OS URL for NCAR users with OS access """
+    url = url.replace(settings.RDA_STRATUS_BASE_URL.rstrip('/'), settings.NCAR_STRATUS_URL.rstrip('/'))
     return url
+
+@register.filter
+def concat_paths(base_path, relative_path):
+    """Concatenate base path and relative path, ensuring there is exactly one '/' between them."""
+    return os.path.join(base_path.strip('/'), relative_path.strip('/'))
 
 @register.filter
 def convert_bytes(bytes):


### PR DESCRIPTION
This pull request introduces improvements to how file paths are constructed and displayed in the dataset file listing template. The main changes involve replacing custom template tags for path generation with a new `concat_paths` filter, streamlining path concatenation logic and making it more explicit. Additionally, a new filter is added to the custom tags module, and an existing filter is updated for clarity and correctness.

Template improvements:

* Replaced `{% get_copy_path %}` calls with explicit concatenation using the new `concat_paths` filter in `filelist-arco-button.html`, simplifying and clarifying path construction for various base URLs.
* Added `{% load custom_tags %}` at the top of `filelist-arco-button.html` to ensure new custom filters are available in the template.

Custom tag enhancements:

* Added a new `concat_paths` filter in `custom_tags.py` to concatenate base and relative paths, ensuring proper formatting.
* Updated the `make_local_os_URL` filter in `custom_tags.py` to use string replacement for URL conversion, improving accuracy and readability.…hs filter