### PR TITLE
Modify swagger table borders

### DIFF
--- a/gdexwebserver/static/css/custom-swagger-ui.css
+++ b/gdexwebserver/static/css/custom-swagger-ui.css
@@ -9,7 +9,7 @@ table td,
 table th,
 .table td,
 .table th {
-  border: none !important;
+  border: none;
 }
 .ncar thead th {
   background-color: transparent !important;


### PR DESCRIPTION
This pull request makes a minor adjustment to the table styling in `custom-swagger-ui.css`. The change removes the `!important` flag from the `border: none` rule for table cells and headers.