### PR TITLE
ISPD subsetting: make regional selection required

### DIFF
--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v23212909372
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v25689852091
     port: 8080
     requests:
       memory: 4Gi

--- a/datasets/static/datasets/js/ispdv4_subset.js
+++ b/datasets/static/datasets/js/ispdv4_subset.js
@@ -632,8 +632,6 @@ function reviewRequest()
 // Validate form inputs
    if(!checkDates()) return;
    if(!checkSpatial()) return;
-   if(form.stationdisplayed.value == 1 && !checkStations()) return;
-   if(form.latlondisplayed.value == 1 && !checkLatLon()) return;
 
    rtype = form.rtype.value;
    gindex = form.gindex.value;

--- a/datasets/static/datasets/js/ispdv4_subset.js
+++ b/datasets/static/datasets/js/ispdv4_subset.js
@@ -114,6 +114,27 @@ function checkDates() {
  return true; 
 } 
 
+/** Validate and process spatial selection */
+function checkSpatial()
+{
+   regionSelection = $('#regionSelectMenu').val();
+
+   if (regionSelection === "") {
+      alert("Please select a spatial range option from the dropdown menu.");
+      return false;
+   }
+   if(regionSelection == "1") {
+      return checkLatLon();
+   }
+   if(regionSelection == "2") {
+      return checkStations();
+   }
+   if(regionSelection == "3") {
+      return getLocations();
+   }
+   return true;
+}
+
 /**
  * Validate location selection
  *
@@ -598,7 +619,7 @@ function displayLocationSelection(action)
 }
 
 /**
- * Review subset selections and submit to dsrqst.php
+ * Review subset selections and submit request
  */
 function reviewRequest()
 {
@@ -610,6 +631,7 @@ function reviewRequest()
    
 // Validate form inputs
    if(!checkDates()) return;
+   if(!checkSpatial()) return;
    if(form.stationdisplayed.value == 1 && !checkStations()) return;
    if(form.latlondisplayed.value == 1 && !checkLatLon()) return;
 

--- a/datasets/templates/datasets/custom-subset-page-d132002.html
+++ b/datasets/templates/datasets/custom-subset-page-d132002.html
@@ -100,8 +100,8 @@
    <div class="mb-1">
       Select spatial region for your data request.
    </div>
-   <select class="custom-select" id="regionSelectMenu" onchange="regionSelectChange()">
-      <option value="" id="nullOption" selected>Choose an option</option>
+   <select class="custom-select" id="regionSelectMenu" onchange="regionSelectChange()" aria-label="Spatial range selection menu" required>
+      <option value="" id="nullOption" disabled selected>Choose an option</option>
       <option value="1" id="mapOption">Select latitude/longitude region</option>
       <option value="2" id="stationOption">Select location by station ID</option>
       <option value="3" id="locationOption">Select by location name</option>

--- a/datasets/templates/datasets/custom-subset-page-d132002.html
+++ b/datasets/templates/datasets/custom-subset-page-d132002.html
@@ -100,7 +100,6 @@
    <div class="mb-1">
       Select spatial region for your data request.
    </div>
-   <select class="custom-select" id="regionSelectMenu" onchange="regionSelectChange()" aria-label="Spatial range selection menu" required>
       <option value="" id="nullOption" disabled selected>Choose an option</option>
       <option value="1" id="mapOption">Select latitude/longitude region</option>
       <option value="2" id="stationOption">Select location by station ID</option>


### PR DESCRIPTION
This pull request makes a small but important accessibility and usability improvement to the spatial region selection menu on the custom subset page.

- Improved accessibility and form validation:
  * Added an `aria-label` and `required` attribute to the `regionSelectMenu` `<select>` element, making it more accessible and ensuring a selection is required.
  * Changed the default "Choose an option" `<option>` to be disabled, preventing users from submitting the form without making a valid selection.