### PR TITLE
Add missing <select> tag

### DIFF
--- a/datasets/templates/datasets/custom-subset-page-d132002.html
+++ b/datasets/templates/datasets/custom-subset-page-d132002.html
@@ -100,6 +100,7 @@
    <div class="mb-1">
       Select spatial region for your data request.
    </div>
+   <select class="custom-select" id="regionSelectMenu" onchange="regionSelectChange()" required></select>
       <option value="" id="nullOption" disabled selected>Choose an option</option>
       <option value="1" id="mapOption">Select latitude/longitude region</option>
       <option value="2" id="stationOption">Select location by station ID</option>

--- a/datasets/templates/datasets/custom-subset-page-d132002.html
+++ b/datasets/templates/datasets/custom-subset-page-d132002.html
@@ -100,7 +100,7 @@
    <div class="mb-1">
       Select spatial region for your data request.
    </div>
-   <select class="custom-select" id="regionSelectMenu" onchange="regionSelectChange()" required></select>
+   <select class="custom-select" id="regionSelectMenu" onchange="regionSelectChange()" required>
       <option value="" id="nullOption" disabled selected>Choose an option</option>
       <option value="1" id="mapOption">Select latitude/longitude region</option>
       <option value="2" id="stationOption">Select location by station ID</option>


### PR DESCRIPTION
This pull request makes a small change to the custom subset page by adding a `select` dropdown menu for selecting the spatial region for a data request. The dropdown now calls a function when its value changes and is marked as required.