### PR TITLE
Reduce WSGI daemon process settings

### DIFF
--- a/apache2/sites-enabled/000-default.conf
+++ b/apache2/sites-enabled/000-default.conf
@@ -15,7 +15,7 @@
 
         IncludeOptional conf-enabled/aliases.conf
 
-        WSGIDaemonProcess gdexweb python-path=/usr/local/gdexweb:/usr/local/gdexweb/lib/python3.11/site-packages request-timeout=180 processes=48 threads=4 header-buffer-size=131072
+        WSGIDaemonProcess gdexweb python-path=/usr/local/gdexweb:/usr/local/gdexweb/lib/python3.11/site-packages request-timeout=180 processes=16 threads=2 header-buffer-size=131072
         WSGIScriptAlias / /usr/local/gdexweb/gdexwebserver/wsgi.py
         WSGIProcessGroup gdexweb
         WSGIApplicationGroup %{GLOBAL}


### PR DESCRIPTION
From research, apparently having large amounts of concurrency from a WSGI application can actually hurt performance. Changing this to test if Internal server error still occurs