### PR TITLE
Add help text to wagtail home page search suggestions

### DIFF
--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v25830249993
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v25881965123
     port: 8080
     requests:
       memory: 4Gi

--- a/home/migrations/0007_alter_homepagesearchsuggestion_fields.py
+++ b/home/migrations/0007_alter_homepagesearchsuggestion_fields.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('home', '0006_homepagesearchsuggestion'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='homepagesearchsuggestion',
+            name='search_term',
+            field=models.CharField(
+                max_length=25,
+                verbose_name='Search Term',
+                help_text='Search term displayed under the home page search bar as a search suggestion badge.  For example, "AI Ready Datasets" or "Zarr Format Datasets".',
+            ),
+        ),
+        migrations.AlterField(
+            model_name='homepagesearchsuggestion',
+            name='search_term_url',
+            field=models.CharField(
+                max_length=255,
+                verbose_name='Search Term URL',
+                help_text='Search term URL specified as the GDEX Search URL to link to when the search term is clicked.  This can be a relative URL or absolute URL. For example, a relative URL could be /gsearch/dataset-search/?q=&filter-match-all.tags=AI%20Ready and an absolute URL could be https://gdex.ucar.edu/gsearch/dataset-search/?q=&filter-match-all.tags=AI%20Ready to link to a search for AI-Ready datasets.',
+            ),
+        ),
+    ]

--- a/home/models.py
+++ b/home/models.py
@@ -242,8 +242,8 @@ class AlertMessage(models.Model):
 
 class HomePageSearchSuggestion(Orderable):
     page = ParentalKey('HomePage', related_name='search_suggestions', on_delete=models.CASCADE)
-    search_term = models.CharField(max_length=25, verbose_name='Search term displayed under the home page search bar as a search suggestion badge.  For example, "AI Ready Datasets" or "Zarr Format Datasets".')
-    search_term_url = models.CharField(max_length=255, verbose_name='Search term URL specified as the GDEX Search URL to link to when the search term is clicked.  This can be a relative URL or absolute URL. For example, a relative URL could be /gsearch/dataset-search/?q=&filter-match-all.tags=AI%20Ready and an absolute URL could be https://gdex.ucar.edu/gsearch/dataset-search/?q=&filter-match-all.tags=AI%20Ready to link to a search for AI-Ready datasets.')
+    search_term = models.CharField(max_length=25, verbose_name='Search Term', help_text='Search term displayed under the home page search bar as a search suggestion badge.  For example, "AI Ready Datasets" or "Zarr Format Datasets".')
+    search_term_url = models.CharField(max_length=255, verbose_name='Search Term URL', help_text='Search term URL specified as the GDEX Search URL to link to when the search term is clicked.  This can be a relative URL or absolute URL. For example, a relative URL could be /gsearch/dataset-search/?q=&filter-match-all.tags=AI%20Ready and an absolute URL could be https://gdex.ucar.edu/gsearch/dataset-search/?q=&filter-match-all.tags=AI%20Ready to link to a search for AI-Ready datasets.')
 
     panels = [
         FieldPanel('search_term'),


### PR DESCRIPTION
This pull request updates the `HomePageSearchSuggestion` model to improve the clarity and usability of its fields. The changes include updating the verbose names and adding helpful descriptions for the `search_term` and `search_term_url` fields, as well as generating a migration to apply these changes to the database.

**Model field improvements:**

* Updated the `search_term` field in `HomePageSearchSuggestion` to use a clearer verbose name ("Search Term") and added a help text explaining its purpose and providing examples. (`home/models.py`, `home/migrations/0007_alter_homepagesearchsuggestion_fields.py`) [[1]](diffhunk://#diff-4d45a7df6555d9855e7c77c5ab5e9778503f5ef80eb2d6637879dd847bb222f6L245-R246) [[2]](diffhunk://#diff-4822c1723d042cc6e9ce338b3b58bc120c01c1fa992154f2e08151749ba8a301R1-R29)
* Updated the `search_term_url` field in `HomePageSearchSuggestion` to use a clearer verbose name ("Search Term URL") and added a help text with usage instructions and examples. (`home/models.py`, `home/migrations/0007_alter_homepagesearchsuggestion_fields.py`) [[1]](diffhunk://#diff-4d45a7df6555d9855e7c77c5ab5e9778503f5ef80eb2d6637879dd847bb222f6L245-R246) [[2]](diffhunk://#diff-4822c1723d042cc6e9ce338b3b58bc120c01c1fa992154f2e08151749ba8a301R1-R29)

**Database migration:**

* Added a new migration (`0007_alter_homepagesearchsuggestion_fields.py`) to apply these verbose name and help text changes to the database schema.