### PR TITLE
Update home page to use Wagtail feature cards

### DIFF
--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v26047069387
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v26048381319
     port: 8080
     requests:
       memory: 4Gi

--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v25881965123
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v26047069387
     port: 8080
     requests:
       memory: 4Gi

--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v26049595513
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v26058682216
     port: 8080
     requests:
       memory: 4Gi

--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v26048381319
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v26049595513
     port: 8080
     requests:
       memory: 4Gi

--- a/home/templates/home/home_grid_cards.html
+++ b/home/templates/home/home_grid_cards.html
@@ -17,7 +17,7 @@
                                 {% endif %}
                             </div>
                             <h4 class="card-title text-center text-white">{{ card.title }}{% if not card.card_page and card.card_url %} <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i>{% endif %}</h4>
-                            <p class="card-text text-center pt-2">{{ card.text }}</p>
+                            <p class="card-text text-center pt-2">{{ card.text|richtext }}</p>
                         </div>
                     </div>
                 </div>

--- a/home/templates/home/home_grid_cards.html
+++ b/home/templates/home/home_grid_cards.html
@@ -17,7 +17,9 @@
                                 {% endif %}
                             </div>
                             <h4 class="card-title text-center text-white">{{ card.title }}{% if not card.card_page and card.card_url %} <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i>{% endif %}</h4>
-                            <p class="card-text text-center pt-2">{{ card.text|richtext }}</p>
+                            <div class="card-text text-center pt-2">
+                                {{ card.text|richtext }}
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/home/templates/home/home_grid_cards.html
+++ b/home/templates/home/home_grid_cards.html
@@ -4,78 +4,24 @@
     <div class="row gx-0 justify-content-center">
         <div class="col-10 primary">
             <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-2 g-md-4">
+                {% for card in page.featured_cards.all %}
                 <div class="col">
                     <div class="card h-100 grid-card-group">
-                        <a href="/gsearch/dataset-search/" class="stretched-link"></a>
+                        <a href="{% if card.card_page %}{{ card.card_page.url }}{% else %}{{ card.card_url }}{% endif %}" class="stretched-link" {% if not card.card_page and card.card_url %}target="_blank" rel="noopener noreferrer"{% endif %}></a>
                         <div class="card-body">
                             <div class="icon py-2 text-center">
-                                <i class="fa-solid fa-magnifying-glass fa-2x"></i>
+                                {% if card.icon_name %}
+                                <i class="fa-solid fa-{{ card.icon_name }} fa-2x"></i>
+                                {% elif card.icomoon_icon_name %}
+                                <i class="{{ card.icomoon_icon_name }}" style="font-size: 3em;"></i>
+                                {% endif %}
                             </div>
-                            <h4 class="card-title text-center text-white">Explore All Datasets</h4>
-                            <p class="card-text text-center pt-2">Browse our dataset collections by category, location, or time</p>
+                            <h4 class="card-title text-center text-white">{{ card.title }}{% if not card.card_page and card.card_url %} <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i>{% endif %}</h4>
+                            <p class="card-text text-center pt-2">{{ card.text }}</p>
                         </div>
                     </div>
                 </div>
-                <div class="col">
-                    <div class="card h-100 grid-card-group">
-                        <div class="card-body">
-                            <a href="https://github.com/NCAR/rda-apps-clients" class="stretched-link" target="_blank"></a>
-                            <div class="icon py-2 text-center">
-                                <i class="fa-solid fa-laptop-code fa-2x"></i>
-                            </div>
-                            <h4 class="card-title text-center text-white">API<i class="fa-solid fa-arrow-up-right-from-square ps-1"></i></h4>
-                            <p class="card-text text-center pt-2">Search GDEX datasets and submit data subset requests</p>
-                        </div>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card h-100 grid-card-group">
-                        <div class="card-body">
-                            <a href="/resources/submit-data/" class="stretched-link"></a>
-                            <div class="icon py-2 text-center">
-                                <i class="fa-solid fa-cloud-arrow-up fa-2x"></i>
-                            </div>
-                            <h4 class="card-title text-center text-white">Deposit Data</h4>
-                            <p class="card-text text-center pt-2">Request to deposit a dataset in GDEX</p>
-                        </div>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card h-100 grid-card-group">
-                        <div class="card-body">
-                            <a href="/resources/gdex-notebook-examples/" class="stretched-link"></a>
-                            <div class="icon py-2 text-center">
-                                <i class="icon-jupyter-logomark" style="font-size: 3em;"></i>
-                            </div>
-                            <h4 class="card-title text-center text-white">JupyterHub</h4>
-                            <p class="card-text text-center pt-2">Access and process GDEX data through NSF NCAR's Community Compute Services</p>
-                        </div>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card h-100 grid-card-group">
-                        <div class="card-body">
-                            <a href="https://arc.ucar.edu/xras_submit/opportunities" class="stretched-link" target="_blank"></a>
-                            <div class="icon py-2 text-center">
-                                <i class="fa-solid fa-network-wired fa-2x"></i>
-                            </div>
-                            <h4 class="card-title text-center text-white">NSF NCAR Compute<i class="fa-solid fa-arrow-up-right-from-square ps-1"></i></h4>
-                            <p class="card-text text-center pt-2">Request an allocation on NSF NCAR Community Compute Services</p>
-                        </div>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card h-100 grid-card-group">
-                        <div class="card-body">
-                            <a href="/metrics/by-the-numbers/" class="stretched-link"></a>
-                            <div class="icon py-2 text-center">
-                                <i class="fa-solid fa-chart-column fa-2x"></i>
-                            </div>
-                            <h4 class="card-title text-center text-white">By the Numbers</h4>
-                            <p class="card-text text-center pt-2">Key metrics and statistics about GDEX usage, including lists of popular and AI-ready datasets</p>
-                        </div>
-                    </div>
-                </div>
+                {% endfor %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
This pull request updates the home page grid cards to be dynamically generated from the `featured_cards` model instead of being hardcoded, allowing for easier updates and customization via the admin interface. Additionally, it updates the web portal container image version in the deployment configuration.

Dynamic home grid cards:

* Refactored `home_grid_cards.html` to render cards dynamically using a loop over `page.featured_cards.all`, replacing previously hardcoded card HTML with a template that pulls card data (title, text, icon, and links) from the model. This allows for easier management and updates of featured cards through the admin panel.
* Updated card icons to support both FontAwesome and Icomoon icons, and improved link handling to open external URLs in a new tab with appropriate security attributes.

Deployment configuration:

* Updated the `gdex-web-portal` container image version in `values.yaml.tcram` from `v25881965123` to `v26047069387` for the web application deployment.