### PR TITLE
Update label for featured cards panel to simplify description

### DIFF
--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v26111925699
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v26113321527
     port: 8080
     requests:
       memory: 4Gi

--- a/home/models.py
+++ b/home/models.py
@@ -329,7 +329,7 @@ class HomePage(Page):
             InlinePanel('search_suggestions', label='Search suggestion'),
         ], heading="Search suggestions", classname="collapsible collapsed"),
         MultiFieldPanel([
-            InlinePanel('featured_cards', label='Cards highlighting popular content with links'),
+            InlinePanel('featured_cards', label='Featured card'),
         ], heading="Featured cards", classname="collapsible collapsed"),
     ]
     is_creatable = False


### PR DESCRIPTION
This pull request makes a minor update to the admin panel configuration for the `HomePage` model. The label for the `featured_cards` inline panel has been changed to be more concise.

* Changed the label for the `featured_cards` inline panel from "Cards highlighting popular content with links" to "Featured card" in the `HomePage` model admin panels for improved clarity.