### PR TITLE
Remove is_creatable attribute from TestHomePage model

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -425,7 +425,6 @@ class TestHomePage(Page):
             InlinePanel('featured_cards', label='Featured card'),
         ], heading="Featured cards", classname="collapsible collapsed"),
     ]
-    is_creatable = False
 
 class TaxonomyTerm(Orderable):
     card = ParentalKey('Card', related_name='taxonomyterm', on_delete=models.CASCADE)


### PR DESCRIPTION
This pull request makes a small change to the `TestHomePage` model by removing the `is_creatable = False` attribute. This may allow instances of `TestHomePage` to be created where previously they could not.