### PR TITLE
Add base.html to test_home_page.html

### DIFF
--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -24,5 +24,4 @@
         {% endblock %}
     </article>
 </div>
-{% include_block page.card_1 %}
 {% endblock %}

--- a/home/templates/home/test_home_page.html
+++ b/home/templates/home/test_home_page.html
@@ -1,3 +1,4 @@
+{% extends "base.html" %}
 {% load wagtailcore_tags %}
 
 {% block content %}


### PR DESCRIPTION
This pull request contains minor updates to the home page templates. The most notable changes are the removal of an included block from the main home page template and the addition of a base template extension to the test home page template.

Template updates:

* Removed the `{% include_block page.card_1 %}` line from `home_page.html`, which previously rendered an additional content block on the home page.
* Added `{% extends "base.html" %}` to the top of `test_home_page.html`, ensuring the test template inherits from the base layout.