### PR TITLE
Add check to block restricted branches for PR source

### DIFF
--- a/.github/workflows/pr-source-check.yml
+++ b/.github/workflows/pr-source-check.yml
@@ -1,0 +1,16 @@
+name: PR Source Branch Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block PRs from restricted branch
+        if: github.head_ref == 'siparcs26'
+        run: |
+          echo "Pull requests from branch 'siparcs26' into main are not allowed."
+          exit 1


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enforce branch restrictions for pull requests. The workflow is designed to block pull requests originating from a specific branch.

**CI/CD and Branch Policy Enforcement:**

* Added a new workflow file, `.github/workflows/pr-source-check.yml`, which checks if a pull request is coming from the `siparcs26` branch and blocks it from being merged into `main`.