### PR TITLE
Order DECS staff by last name

### DIFF
--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v28052051992
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v28053730188
     port: 8080
     requests:
       memory: 4Gi

--- a/gdexwebserver/templates/unity/decs_staff.html
+++ b/gdexwebserver/templates/unity/decs_staff.html
@@ -7,7 +7,7 @@
         <div class="staff-person row gx-0"">
             <div class="ps-2 ps-sm-3 text-gray-darkest">
                 <div class="staff-name">
-                    {{ staff.name }}
+                    {{ staff.first_name }} {{ staff.last_name }}
                 </div>                                
                 <div class="d-flex flex-column flex-sm-row">
                     <div class="staff-email i-envelope--before text-gray-dark mb1 mb-sm-0 me-sm-4">

--- a/home/templatetags/home_tags.py
+++ b/home/templatetags/home_tags.py
@@ -12,7 +12,7 @@ register = template.Library()
 @register.inclusion_tag('unity/decs_staff.html', takes_context=True)
 def decs_staff(context):
     return {
-        'decs_staff': DecsStaff.objects.all().order_by('name'),
+        'decs_staff': DecsStaff.objects.all().order_by('last_name'),
         'request': context['request'],
     }
 


### PR DESCRIPTION
This pull request focuses on improving the display and ordering of GDEX staff information, as well as updating the web application container image version. The main changes update how staff names are rendered, ensure staff are listed alphabetically by last name, and deploy a new application version.

**Improvements to staff display and ordering:**

* Updated the staff listing in `decs_staff.html` to display each staff member's first and last name separately, rather than using a single `name` field.
* Changed the staff ordering in the `decs_staff` template tag (`home_tags.py`) to sort by `last_name` instead of `name`, ensuring alphabetical listing by last name.

**Deployment update:**

* Updated the container image version for the web application in `app-chart/values.yaml.tcram` to `v28053730188` for deployment.