### PR TITLE
Add description field to TestHomePageSearchSuggestion and card_link_text to TestHomePageFeaturedCard

### DIFF
--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v27971049668
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v28058250872
     port: 8080
     requests:
       memory: 4Gi

--- a/home/models.py
+++ b/home/models.py
@@ -339,10 +339,12 @@ class TestHomePageSearchSuggestion(Orderable):
     page = ParentalKey('TestHomePage', related_name='search_suggestions', on_delete=models.CASCADE)
     search_term = models.CharField(max_length=25, verbose_name='Search Term', help_text='Search term displayed under the home page search bar as a search suggestion badge.  For example, "AI Ready Datasets" or "Zarr Format Datasets".')
     search_term_url = models.CharField(max_length=255, verbose_name='Search Term URL', help_text='Search term URL specified as the GDEX Search URL to link to when the search term is clicked.  This can be a relative URL or absolute URL. For example, a relative URL could be /gsearch/dataset-search/?q=&filter-match-all.tags=AI%20Ready and an absolute URL could be https://gdex.ucar.edu/gsearch/dataset-search/?q=&filter-match-all.tags=AI%20Ready to link to a search for AI-Ready datasets.')
+    description = models.CharField(max_length=100, blank=True, default="", verbose_name='Search Term Description', help_text='Optional short description of the search term to be displayed under the search term badge.  For example, "Datasets prepared for AI/ML applications" or "Cloud-optimized array data".')
 
     panels = [
         FieldPanel('search_term'),
         FieldPanel('search_term_url'),
+        FieldPanel('description'),
     ]
 
 class TestHomePageFeaturedCard(Orderable):
@@ -384,6 +386,11 @@ class TestHomePageFeaturedCard(Orderable):
         related_name='+',
         verbose_name="Card Page",
         help_text="Internal page to link to from the card. If both Card Page and Card URL are provided, Card Page will take precedence.",
+    )
+    card_link_text = models.CharField(
+        max_length=100,
+        default='Learn more',
+        help_text="Text displayed for the link to the related URL.  Default='Learn more'",
     )
 
     panels = [

--- a/home/models.py
+++ b/home/models.py
@@ -400,6 +400,7 @@ class TestHomePageFeaturedCard(Orderable):
         FieldPanel('text'),
         FieldPanel('card_url'),
         PageChooserPanel('card_page'),
+        FieldPanel('card_link_text'),
     ]
 
     def clean(self):


### PR DESCRIPTION
This pull request adds new optional fields to the `TestHomePageSearchSuggestion` and `TestHomePageFeaturedCard` models in `home/models.py` to enhance the display and customization of search suggestions and featured cards on the homepage.

**Enhancements to homepage models:**

* Added a `description` field to `TestHomePageSearchSuggestion` for displaying an optional short description under each search suggestion badge.
* Added a `card_link_text` field to `TestHomePageFeaturedCard` to allow customization of the link text for card URLs, with a default value of "Learn more".