### PR TITLE
Move TEST INSTANCE alert to top of page

### DIFF
--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v28058958646
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v28182736200
     port: 8080
     requests:
       memory: 4Gi

--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v28182736200
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v28187583533
     port: 8080
     requests:
       memory: 4Gi

--- a/gdexwebserver/templates/base.html
+++ b/gdexwebserver/templates/base.html
@@ -80,9 +80,6 @@
     <body class="ncar{% block body_class %}{% endblock %}">
         {% include "unity/header_decs.html" %}
         {% alerts %}
-        {% if request.get_host|slice:"0:4" != "gdex" and request.get_host|slice:"0:8" != "api.gdex" %}
-        <font color="red">TEST INSTANCE!</font> {{ request.get_host }}
-        {% endif %}
         <main class="container-lg py-3 pt-md-4">
             {% include "unity/breadcrumbs.html" %}
             {% block content %}{% endblock %}

--- a/gdexwebserver/templates/unity/header_decs.html
+++ b/gdexwebserver/templates/unity/header_decs.html
@@ -2,7 +2,7 @@
 
 <header>
     {% if request.get_host|slice:"0:4" != "gdex" and request.get_host|slice:"0:8" != "api.gdex" %}
-        <div class="alert alert-warning text-center mb-0" role="alert">
+        <div class="alert alert-warning text-center mb-0 fw-bold" role="alert">
             TEST INSTANCE - {{ request.get_host }}
         </div>
     {% endif %}

--- a/gdexwebserver/templates/unity/header_decs.html
+++ b/gdexwebserver/templates/unity/header_decs.html
@@ -1,6 +1,11 @@
 {% load decs_tags menu_tags %}
 
 <header>
+    {% if request.get_host|slice:"0:4" != "gdex" and request.get_host|slice:"0:8" != "api.gdex" %}
+        <div class="alert alert-danger text-center mb-0" role="alert">
+            TEST INSTANCE - {{ request.get_host }}
+        </div>
+    {% endif %}
     <nav class="navbar navbar-expand-md navbar-light align-items-start py-0">
         <div class="container-fluid px-0">
             <div class="row gx-0 flex-grow-1">

--- a/gdexwebserver/templates/unity/header_decs.html
+++ b/gdexwebserver/templates/unity/header_decs.html
@@ -1,11 +1,13 @@
 {% load decs_tags menu_tags %}
 
+{% if request.get_host|slice:"0:4" != "gdex" and request.get_host|slice:"0:8" != "api.gdex" %}
+    <div class="alert alert-warning text-center mb-0 fw-bold sticky-top" role="alert">
+        <i class="fa-solid fa-triangle-exclamation me-2"></i>
+        TEST INSTANCE - {{ request.get_host }}
+    </div>
+{% endif %}
+
 <header>
-    {% if request.get_host|slice:"0:4" != "gdex" and request.get_host|slice:"0:8" != "api.gdex" %}
-        <div class="alert alert-warning text-center mb-0 fw-bold" role="alert">
-            TEST INSTANCE - {{ request.get_host }}
-        </div>
-    {% endif %}
     <nav class="navbar navbar-expand-md navbar-light align-items-start py-0">
         <div class="container-fluid px-0">
             <div class="row gx-0 flex-grow-1">

--- a/gdexwebserver/templates/unity/header_decs.html
+++ b/gdexwebserver/templates/unity/header_decs.html
@@ -2,7 +2,7 @@
 
 <header>
     {% if request.get_host|slice:"0:4" != "gdex" and request.get_host|slice:"0:8" != "api.gdex" %}
-        <div class="alert alert-danger text-center mb-0" role="alert">
+        <div class="alert alert-warning text-center mb-0" role="alert">
             TEST INSTANCE - {{ request.get_host }}
         </div>
     {% endif %}


### PR DESCRIPTION
This pull request updates how the "TEST INSTANCE" warning is displayed for non-production environments. The main change is moving the warning message from a plain font tag in `base.html` to a styled Bootstrap alert in the `header_decs.html` template, improving visibility and consistency.

**UI Improvements:**

* Replaced the plain "TEST INSTANCE" warning in `base.html` with a Bootstrap-styled alert in `header_decs.html` for better visibility and user experience. [[1]](diffhunk://#diff-3f22009109c70a9509f64eec56df1e711ac2c5ef8d79a366c2d270f5c42b8c15L83-L85) [[2]](diffhunk://#diff-6a80329042734c295cc05239d8601bfdb481b3076d420c36706082e8b3b791fbR4-R8)