### PR TITLE
Add custom subset page template

### DIFF
--- a/datasets/templates/datasets/custom_subset_page.html
+++ b/datasets/templates/datasets/custom_subset_page.html
@@ -1,13 +1,6 @@
 {% extends "datasets/custom-subset-page-base.html" %}
 {% load wagtailcore_tags static %}
 {% block content %}
-  <h1>{{ dataset.name }}</h1>
-  <p>{{ dataset.description }}</p>
-
-  <h2>Subset Information</h2>
-  <ul>
-    {% for subset in dataset.subsets %}
-      <li>{{ subset.name }}: {{ subset.description }}</li>
-    {% endfor %}
-  </ul>
+  <h1>{{ page.title }}</h1>
+  <p>{{ page.header }}</p>
 {% endblock %}

--- a/datasets/templates/datasets/custom_subset_page.html
+++ b/datasets/templates/datasets/custom_subset_page.html
@@ -1,0 +1,13 @@
+{% extends "datasets/custom-subset-page-base.html" %}
+
+{% block content %}
+  <h1>{{ dataset.name }}</h1>
+  <p>{{ dataset.description }}</p>
+
+  <h2>Subset Information</h2>
+  <ul>
+    {% for subset in dataset.subsets %}
+      <li>{{ subset.name }}: {{ subset.description }}</li>
+    {% endfor %}
+  </ul>
+{% endblock %}

--- a/datasets/templates/datasets/custom_subset_page.html
+++ b/datasets/templates/datasets/custom_subset_page.html
@@ -1,5 +1,5 @@
 {% extends "datasets/custom-subset-page-base.html" %}
-
+{% load wagtailcore_tags static %}
 {% block content %}
   <h1>{{ dataset.name }}</h1>
   <p>{{ dataset.description }}</p>


### PR DESCRIPTION
This pull request adds a new template for rendering custom dataset subset pages. The template extends a base layout and displays key information about the dataset and its subsets.

Template addition:

* Added `custom_subset_page.html` template to display the dataset's name, description, and a list of its subsets with their descriptions.