### PR TITLE
Add conditional display for DatasetDescriptionPage types

### DIFF
--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v28200507295
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v28399535848
     port: 8080
     requests:
       memory: 4Gi

--- a/datasets/templates/datasets/datasets_page.html
+++ b/datasets/templates/datasets/datasets_page.html
@@ -9,11 +9,13 @@
                 <div class="main-content clearfix">{{ page.description|richtext }}</div>
                 <div class="component list">
                     {% for child in page.get_children.specific %}
+                    {% if child.content_type.model == "datasetdescriptionpage" %}
                         <div class="list-item p-3">
                             {% with dsid=child.dsid|format_dsid %}
                             <div><a href="{{ dsid|ds_slug }}/">{{ dsid }}</a> - {{ child.dstitle }}</div>
                             {% endwith %}
                         </div>
+                    {% endif %}
                     {% endfor %}
                 </div>
             </article>


### PR DESCRIPTION
This pull request includes a container image update for the web application and an improvement to the datasets page template to ensure only relevant child pages are displayed.

**Web Application Deployment:**
- Updated the `gdex-web-portal` container image version in `app-chart/values.yaml.tcram` to `v28399535848` for the `webapp` deployment.

**Datasets Page Template:**
- Modified the `datasets_page.html` template to display only children of type `datasetdescriptionpage`, preventing unrelated page types from appearing in the dataset list.