### PR TITLE
Change template inheritance to use base.html in custom subset page

### DIFF
--- a/datasets/templates/datasets/custom_subset_page.html
+++ b/datasets/templates/datasets/custom_subset_page.html
@@ -1,4 +1,4 @@
-{% extends "datasets/custom-subset-page-base.html" %}
+{% extends "base.html" %}
 {% load wagtailcore_tags static %}
 {% block content %}
   <h1>{{ page.title }}</h1>


### PR DESCRIPTION
This pull request updates the template inheritance for the `custom_subset_page.html` template to use the site-wide `base.html` instead of a specialized base template.

- Template inheritance update:
  * Changed `{% extends "datasets/custom-subset-page-base.html" %}` to `{% extends "base.html" %}` in `datasets/templates/datasets/custom_subset_page.html` to standardize the layout and ensure consistency across pages.