### PR TITLE
Add description paragraph to custom subset page template

### DIFF
--- a/datasets/templates/datasets/custom_subset_page.html
+++ b/datasets/templates/datasets/custom_subset_page.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% load wagtailcore_tags static %}
+
 {% block content %}
   <h1>{{ page.title }}</h1>
   <p>{{ page.header }}</p>
+  <p>{{ page.description }}</p>
 {% endblock %}


### PR DESCRIPTION
This pull request makes a small update to the `custom_subset_page.html` template by displaying the page's description field on the page.