### PR TITLE
datasets - fix software table response

### DIFF
--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v28399535848
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v29049896427
     port: 8080
     requests:
       memory: 4Gi

--- a/datasets/views.py
+++ b/datasets/views.py
@@ -248,15 +248,22 @@ def examples_page(request, dsnum):
 def get_software_table(request, dsnum):
     hostname = get_hostname()
     dsid = format_dataset_id(dsnum)
-    api_uri = '/api/datasets/{}/software'.format(dsid)
+    api_uri = f'/api/datasets/{dsid}/software'
     url = hostname + api_uri
     software = requests.get(url)
     software = software.content
     software_json = json.loads(software)
-    return description(request, dsnum,
-                       template="datasets/software_table.html",
-                       page_context=software_json)
 
+    template = "datasets/software_table.html"
+    
+    if "HTTP_X_REQUESTED_WITH" in request.META:
+        return render(request,
+                      template,
+                      software_json)
+    else:
+        return description(request, dsnum,
+                           template=template,
+                           page_context=software_json)
 
 def get_filelist_table(request, dsnum, groupid=None):
     hostname = get_hostname()


### PR DESCRIPTION
This pull request refactors the `get_software_table` view in `datasets/views.py` to improve code clarity and add support for handling AJAX requests. The main changes include using f-strings for URL formatting, simplifying template usage, and conditionally rendering the template based on the request type.

**Improvements to code clarity and maintainability:**

* Replaced string formatting with f-strings for constructing the `api_uri` in `get_software_table`, making the code more readable.
* Assigned the template name to a variable (`template`) for consistency and easier maintenance.

**AJAX support and conditional rendering:**

* Added logic to check for the `"HTTP_X_REQUESTED_WITH"` header in `request.META` to determine if the request is an AJAX call. If so, the view directly renders the `software_table.html` template with the software data; otherwise, it falls back to the existing `description` function for rendering.