### PR TITLE
datasets - update station ID input for custom subset requests

### DIFF
--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v29605365712
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v29606121846
     port: 8080
     requests:
       memory: 4Gi

--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v29534790082
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v29602964468
     port: 8080
     requests:
       memory: 4Gi

--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v29602964468
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v29605365712
     port: 8080
     requests:
       memory: 4Gi

--- a/datasets/forms.py
+++ b/datasets/forms.py
@@ -118,18 +118,18 @@ class BUFRSubsetForm(forms.Form):
     )
 
     # ------------------------------------------------------------------
-    # Station IDs (comma-separated list of 5-digit WMO numbers)
+    # Station IDs (comma-separated list of 5 or 6 digit WMO numbers)
     # ------------------------------------------------------------------
-    station0  = forms.CharField(
+    stationIDs  = forms.CharField(
         required=False,
-        min_length=5, 
-        max_length=5,
+        min_length=5,
+        max_length=6,
         label='Station IDs (comma-separated)',
         widget=forms.Textarea(attrs={
             'class': 'form-control stns', 
             'rows': '4', 
             'tabindex': '1',
-            'id': 'station0',
+            'id': 'stationIDs',
         }),
     )
 

--- a/datasets/forms.py
+++ b/datasets/forms.py
@@ -171,6 +171,106 @@ class BUFRSubsetForm(forms.Form):
             raise forms.ValidationError('Start date must not be later than end date.')
         return cleaned
     
+class ISPDSubsetForm(forms.Form):
+    """ ISPD subset form for dataset d132002 """
+
+    SPATIAL_CHOICES = [
+        ('-1', 'Choose a spatial subset preference'),
+        ('0', 'Select latitude/longitude region via map'),
+        ('1', 'Select location by station ID'),
+        ('2', 'Select location by location name'),
+    ]
+    OBSERVATION_TYPE_CHOICES = [
+        ('RADIOSONDE', 'Radiosonde observations'),
+        ('DROPSONDE', 'Dropsonde observations'),
+        ('MARINE', 'Marine observations'),
+        ('SFC_STATION', 'Surface station observations'),
+        ('TC_BEST_TRACK', 'Tropical Cyclone Best Track observations'),
+    ]
+    COMPRESSION_CHOICES = [
+        ('gz', '.gz (Gzip)'),
+        ('None', 'No compression'),
+    ]
+
+    start_date = forms.DateField(
+        required=False, 
+        label='Start Date', 
+        input_formats=['%Y-%m-%d'], 
+        widget=forms.TextInput(attrs={
+            'placeholder': 'YYYY-MM-DD', 
+            'size': '10', 
+            'maxlength': '10'
+            }
+        ),
+    )
+    end_date = forms.DateField(
+        required=False, 
+        label='End Date', 
+        input_formats=['%Y-%m-%d'], 
+        widget=forms.TextInput(attrs={
+            'placeholder': 'YYYY-MM-DD', 
+            'size': '10', 
+            'maxlength': '10'
+            }
+        ),
+    )
+    grid_selection = forms.ChoiceField(
+        required=True, 
+        choices=SPATIAL_CHOICES, 
+        label='Spatial Subset Preference',
+        widget=forms.Select(attrs={
+            'class': 'custom-select', 
+            'id': 'gridSelectionMenu', 
+            'onchange': 'displayGridSelection(document.form.grid_selection.value)'
+            }
+        ),
+    )
+    station_ids = forms.CharField(
+        required=False, 
+        min_length=5, 
+        label='Station IDs (comma-separated)',
+        widget=forms.Textarea(attrs={
+            'class': 'form-control stns', 
+            'rows': '4', 
+            'tabindex': '1', 
+            'id': 'stationIDs'
+            }
+        ),
+    )
+    location_names = forms.CharField(
+        required=False, 
+        label='Location Names (comma-separated)',
+        widget=forms.Textarea(attrs={
+            'class': 'form-control locs', 
+            'rows': '4', 
+            'tabindex': '1', 
+            'id': 'locationNames'
+            }
+        ),
+    )
+    observation_types = forms.MultipleChoiceField(
+        required=False, 
+        choices=OBSERVATION_TYPE_CHOICES,
+        label='Observation Types',
+        widget=forms.CheckboxSelectMultiple(attrs={'class': 'form-check-input'}),
+    )
+
+    dsid = forms.CharField(widget=forms.HiddenInput, required=False)
+    gindex = forms.IntegerField(widget=forms.HiddenInput, required=False, initial=1)
+    rtype = forms.CharField(widget=forms.HiddenInput, required=False, initial='S')
+    tlat = forms.CharField(widget=forms.HiddenInput, required=False)
+    blat = forms.CharField(widget=forms.HiddenInput, required=False)
+    llon = forms.CharField(widget=forms.HiddenInput, required=False)
+    rlon = forms.CharField(widget=forms.HiddenInput, required=False)
+
+    def clean(self):
+        cleaned = super().clean()
+        start = cleaned.get('startDate')
+        end   = cleaned.get('endDate')
+        if start and end and start > end:
+            raise forms.ValidationError('Start date must not be later than end date.')
+        return cleaned
+
 def validate_dsid(value):
     if not re.match(r'^[a-z]{1}[0-9]{6}$', value):
         raise forms.ValidationError("Dataset ID format must be 'd123456'.")

--- a/datasets/forms.py
+++ b/datasets/forms.py
@@ -123,7 +123,6 @@ class BUFRSubsetForm(forms.Form):
     stationIDs  = forms.CharField(
         required=False,
         min_length=5,
-        max_length=6,
         label='Station IDs (comma-separated)',
         widget=forms.Textarea(attrs={
             'class': 'form-control stns', 

--- a/datasets/forms.py
+++ b/datasets/forms.py
@@ -121,13 +121,16 @@ class BUFRSubsetForm(forms.Form):
     # Station IDs (comma-separated list of 5-digit WMO numbers)
     # ------------------------------------------------------------------
     station0  = forms.CharField(
-        required=False, 
-        max_length=5, 
-        label='Station 1',  
+        required=False,
+        min_length=5, 
+        max_length=5,
+        label='Station IDs (comma-separated)',
         widget=forms.Textarea(attrs={
             'class': 'form-control stns', 
-            'rows': '4', 'tabindex': '1'
-            }),
+            'rows': '4', 
+            'tabindex': '1',
+            'id': 'station0',
+        }),
     )
 
     # ------------------------------------------------------------------

--- a/datasets/forms.py
+++ b/datasets/forms.py
@@ -192,6 +192,10 @@ class ISPDSubsetForm(forms.Form):
         ('None', 'No compression'),
     ]
 
+    def __init__(self, *args, **kwargs):
+        self.dsid = kwargs.pop('dsid', None)
+        super(ISPDSubsetForm, self).__init__(*args, **kwargs)
+
     start_date = forms.DateField(
         required=False, 
         label='Start Date', 
@@ -257,7 +261,7 @@ class ISPDSubsetForm(forms.Form):
 
     dsid = forms.CharField(widget=forms.HiddenInput, required=False)
     gindex = forms.IntegerField(widget=forms.HiddenInput, required=False, initial=1)
-    rtype = forms.CharField(widget=forms.HiddenInput, required=False, initial='S')
+    rtype = forms.CharField(widget=forms.HiddenInput, required=False, initial='T')
     tlat = forms.CharField(widget=forms.HiddenInput, required=False)
     blat = forms.CharField(widget=forms.HiddenInput, required=False)
     llon = forms.CharField(widget=forms.HiddenInput, required=False)

--- a/datasets/static/datasets/js/BUFR_subset.js
+++ b/datasets/static/datasets/js/BUFR_subset.js
@@ -193,7 +193,7 @@ function checkStations()
    // check stations
    countValid = 0;   // Count the valid entries
 
-   stationInput = document.getElementById("station0").value;
+   stationInput = document.getElementById("stationIDs").value;
    if (stationInput == "" || stationInput == null) {
       alert("Please enter at least one station ID or select a different spatial range option.");
       return false;

--- a/datasets/static/datasets/js/BUFR_subset.js
+++ b/datasets/static/datasets/js/BUFR_subset.js
@@ -515,19 +515,6 @@ function checkParameters()
 }
 
 /**
- * function to show/hide google map
- */
-function displayGoogleMap(act)
-{
-   if(act == 1) {
-      $("#mapselect").show();
-   } else {
-      setSpaceValues();
-      $("#mapselect").hide();
-   }
-}
-
-/**
  * function to show appropriate spatial subsetting selection
  */
 function displayGridSelection(value)
@@ -540,7 +527,7 @@ function displayGridSelection(value)
   
   // Google map lat/lon selection
   if (value == 0) {
-    displayGoogleMap(1);
+    $("#mapselect").show();
     $("#stationSelect").hide();
   }
 

--- a/datasets/static/datasets/js/ispdv4_subset.js
+++ b/datasets/static/datasets/js/ispdv4_subset.js
@@ -117,7 +117,7 @@ function checkDates() {
 /** Validate and process spatial selection */
 function checkSpatial()
 {
-   regionSelection = $('#regionSelectMenu').val();
+   regionSelection = $('#gridSelectionMenu').val();
 
    if (regionSelection == "-1" || regionSelection == null) {
       alert("Please select a spatial range option from the dropdown menu.");
@@ -152,7 +152,7 @@ function checkStations()
    // check stations
    countValid = 0;   // Count the valid entries
 
-   stationInput = document.getElementById("station0").value;
+   stationInput = document.getElementById("stationIDs").value;
    if (stationInput == "" || stationInput == null) {
       alert("Please enter at least one station ID or select a different spatial range option.");
       return false;
@@ -260,7 +260,7 @@ function checkLatLon()
    var value, unit;
    
    i = 0;
-   if(form.mapdisplayed.value == 1) setSpaceValues();
+   setSpaceValues();
    
    max = goodCoordinate(form.tlat.value, true);
    if(max == 999) {
@@ -490,139 +490,24 @@ function getTypes()
   return true;  
 }
 
-function regionSelectChange()
+function displayGridSelection(value)
 {
-   var selectedValue = $('#regionSelectMenu').val();
-
-   if (selectedValue === "-1") {
-      hideRegionSelection();
-   } else if(selectedValue == "1") {
-      displayGoogleMap(1);
-   } else if(selectedValue == "2") {
-      displayStationSelection(1);
-   } else if(selectedValue == "3") {
-      displayLocationSelection(1);
-   }
-}
-
-/** Hide all region selection sections */
-function hideRegionSelection()
-{
-   $("#mapselect").hide();
-   $("#manselect").hide();
-   $("#stationSelect").hide();
-   $("#locationSelect").hide();
-
-   $("form input[name='mapdisplayed']").val(0);
-   $("form input[name='mandisplayed']").val(0);
-   $("form input[name='latlondisplayed']").val(0);
-   $("form input[name='stationdisplayed']").val(0);
-   $("form input[name='locationdisplayed']").val(0);
-}
-
-/**
- * function to show/hide google map
- */
-function displayGoogleMap(act)
-{
-   var mapdisp = $("#mapselect");
-   var mandisp = $("#manselect");
-   var stationdisp = $("#stationSelect");
-   var locationdisp = $("#locationSelect");
-
-   if(act == 1) {
-      mapdisp.show();
-      mandisp.hide();
-      stationdisp.hide();
-      locationdisp.hide();
-
-      document.form.mapdisplayed.value = 1;
-      document.form.mandisplayed.value = 0;
-      document.form.latlondisplayed.value = 1;
-      document.form.stationdisplayed.value = 0;
-      document.form.locationdisplayed.value = 0;
-   } else {
-      setSpaceValues();
-      mapdisp.hide();
-      mandisp.hide();
-      stationdisp.hide();
-      locationdisp.hide();
-
-      document.form.mapdisplayed.value = 0;
-      document.form.mandisplayed.value = 0;
-      document.form.latlondisplayed.value = 0;
-      document.form.stationdisplayed.value = 0;
-      document.form.locationdisplayed.value = 0;
-   }
-}
-
-/**
- * function to show/hide station ID selection
- */
-function displayStationSelection(action)
-{
-   var stationdisp = $("#stationSelect");
-   var locationdisp = $("#locationSelect");
-   var mapdisp     = $("#mapselect");
-   var mandisp     = $("#manselect");
-   
-   if(action == 1) {
-      stationdisp.show();
-      mapdisp.hide();
-      mandisp.hide();
-      locationdisp.hide();
-
-      document.form.latlondisplayed.value = 0;
-      document.form.mapdisplayed.value = 0;
-      document.form.mandisplayed.value = 0;
-      document.form.stationdisplayed.value = 1;
-      document.form.locationdisplayed.value = 0;
-   } else {
-      stationdisp.hide();
-      mapdisp.hide();
-      mandisp.hide();
-      locationdisp.hide();
-      
-      document.form.latlondisplayed.value = 0;
-      document.form.mapdisplayed.value = 0;
-      document.form.mandisplayed.value = 0;
-      document.form.stationdisplayed.value = 0;
-      document.form.locationdisplayed.value = 0;
-   }
-}
-
-/**
- * function to show/hide station ID selection
- */
-function displayLocationSelection(action)
-{
-   var stationdisp = $("#stationSelect");
-   var locationdisp = $("#locationSelect");
-   var mapdisp     = $("#mapselect");
-   var mandisp     = $("#manselect");
-   
-   if(action == 1) {
-      locationdisp.show();
-      mapdisp.hide();
-      mandisp.hide();
-      stationdisp.hide();
-
-      document.form.latlondisplayed.value = 0;
-      document.form.mapdisplayed.value = 0;
-      document.form.mandisplayed.value = 0;
-      document.form.stationdisplayed.value = 0;
-      document.form.locationdisplayed.value = 1;
-   } else {
-      locationdisp.hide();
-      mapdisp.hide();
-      mandisp.hide();
-      stationdisp.hide();
-      
-      document.form.latlondisplayed.value = 0;
-      document.form.mapdisplayed.value = 0;
-      document.form.mandisplayed.value = 0;
-      document.form.stationdisplayed.value = 0;
-      document.form.locationdisplayed.value = 0;
+   if (value === "-1") {
+      $('#mapselect').hide();
+      $('#stationSelect').hide();
+      $('#locationSelect').hide();
+   } else if(value == "0") {
+      $('#mapselect').show();
+      $('#stationSelect').hide();
+      $('#locationSelect').hide();
+   } else if(value == "1") {
+      $('#stationSelect').show();
+      $('#mapselect').hide();
+      $('#locationSelect').hide();
+   } else if(value == "2") {
+      $('#locationSelect').show();
+      $('#mapselect').hide();
+      $('#stationSelect').hide();
    }
 }
 
@@ -708,22 +593,22 @@ function gather_request_info()
    lons = form.llon.value + ", " + form.rlon.value;
    getTypes();
    comp = get_compress_info();
-//   fmt = get_fmt_info();
    fmt = "ascii";
 
    rnote = "Date Limits           : " + dates;
    rinfo = "dates=" + dates;
 
-   if(form.latlondisplayed.value == 1) {
+   gridSelection = $('[name="gridSelection"]').val();
+   if(gridSelection == "0") {
      rnote += "\nLatitude Limits       : " + lats +
               "\nLongitude Limits      : " + lons;
      rinfo += "&lats=" + lats + "&lons=" + lons;
-   } else if (locations && form.locationdisplayed.value == 1) {
-     rnote += "\nLocations              : " + locations;
-     rinfo += "&loc=" + locations;
-   } else if (stations && form.stationdisplayed.value == 1) {
+   } else if (gridSelection == "1") {
      rnote += "\nStation ID            : " + stations;
      rinfo += "&stn=" + stations;
+   } else if (gridSelection == "2") {
+     rnote += "\nLocations              : " + locations;
+     rinfo += "&loc=" + locations;
    }   
 
    if(types){
@@ -769,66 +654,6 @@ function get_fmt_info()
       }
    }
    return "ascii";
-}
-
-/**
- * Add additional fields to station ID form input
- */
-function addStation()
-{
-  if (stationCounter == stationLimit) {
-    alert("You have reached the limit of " + stationCounter + " station inputs");
-  } else if (stationCounter < stationLimit/2) {
-    var tbl = document.getElementById('stationTable');
-    var lastRow = tbl.rows.length;
-    var row = tbl.insertRow(lastRow);
-    
-    // Left cell
-    var cellLeft = row.insertCell(0);
-//    var fontElem = document.createElement('font');
-//    fontElem.style.fontSize="small";
-//    fontElem.style.color="#000000";
-//    fontElem.appendChild(document.createTextNode('Station '+(stationCounter+1)+' '));
-//    cellLeft.appendChild(fontElem);
-    cellLeft.className="body";
-    cellLeft.style.textAlign="left";
-    cellLeft.appendChild(document.createTextNode('Station '+(stationCounter+1)+' '));
-
-    // Right cell
-    var cellRight = row.insertCell(1);
-    var elem = document.createElement('input');
-    elem.type = 'text';
-    elem.name = 'station' + stationCounter;
-    elem.id = 'station' + stationCounter;
-    elem.size = 6;
-    elem.maxlength = 6;
-    cellRight.appendChild(elem);
-    
-    // Add two more blank cells
-    var cellThree = row.insertCell(2);
-    cellThree.className="body";
-    cellThree.style.textAlign="left";
-    var cellFour  = row.insertCell(3);
-  
-    stationCounter++;
-  } else {
-    var tbl = document.getElementById('stationTable');
-    var thisRow = stationCounter-(stationLimit/2);
-//    var fontElem = document.createElement('font');
-//    fontElem.style.fontSize="small";
-//    fontElem.style.color="#000000";
-//    fontElem.appendChild(document.createTextNode('Station '+(stationCounter+1)+' '));
-//    tbl.rows[thisRow].cells[2].appendChild(fontElem);
-    tbl.rows[thisRow].cells[2].appendChild(document.createTextNode('Station '+(stationCounter+1)+' '));
-    var elem = document.createElement('input');
-    elem.type = 'text';
-    elem.name = 'station' + stationCounter;
-    elem.id = 'station' + stationCounter;
-    elem.size = 6;
-    elem.maxlength = 6;
-    tbl.rows[thisRow].cells[3].appendChild(elem);
-    stationCounter++;
-  }
 }
 
 /**

--- a/datasets/templates/datasets/custom-subset-page-d132002.html
+++ b/datasets/templates/datasets/custom-subset-page-d132002.html
@@ -124,8 +124,8 @@
       look up station IDs in the ISPD version 4 inventory 
       <a href="https://osdata.gdex.ucar.edu/web/datasets/d132002/docs/ispd_history_v4.00.txt">here</a>.
    </div>
-   <label for="station0">Station IDs (comma separated): </label>
-   <textarea class="form-control" name="station0" id="station0" rows="4"></textarea>
+   <label class="form-label" for="stationIDs">Station IDs (comma separated): </label>
+   <textarea class="form-control" name="stationIDs" id="stationIDs" rows="4"></textarea>
 </div>
 
 <!-- Select location by location name -->
@@ -148,7 +148,7 @@
       for London Heathrow Airport, London Gatwick Airport, and other observation
       records with "London" in the station name field.
    </div>
-   <label for="location0">Enter locations (comma separated): </label>
+   <label class="form-label" for="location0">Enter locations (comma separated): </label>
    <textarea class="form-control" name="location0" id="location0" rows="1" cols="50"></textarea>
 </div>
 

--- a/datasets/templates/datasets/custom-subset-page-d132002.html
+++ b/datasets/templates/datasets/custom-subset-page-d132002.html
@@ -34,20 +34,19 @@
    <div id="request-form" class="component webform yellow-orange-border p-2 mb-4">
 
    <form id="subset-form" name="form">
-   <input type="hidden" name="dsid" value="{{ subset.dsid }}">
-   <input type="hidden" name="gindex" value="{{ subset.gindex|default:'1' }}">
-   <input type="hidden" name="rtype" value="T">
-   <input type="hidden" id="minDate" value="{{ subset.date_start }}">
-   <input type="hidden" id="maxDate" value="{{ subset.date_end }}">
-   <input type="hidden" name="mapdisplayed" value=0>
-   <input type="hidden" name="mandisplayed" value=0>
-   <input type="hidden" name="latlondisplayed" value=0>
-   <input type="hidden" name="stationdisplayed" value=0>
-   <input type="hidden" name="locationdisplayed" value=0>
-   <input type="hidden" name="tlat" type="text" value="">
-   <input type="hidden" name="blat" type="text" value="">
-   <input type="hidden" name="llon" type="text" value="">
-   <input type="hidden" name="rlon" type="text" value="">
+
+      {# --- Hidden fields rendered directly from the form --- #}
+      {{ form.dsid }}
+      {{ form.gindex }}
+      {{ form.rtype }}
+      {{ form.tlat }}
+      {{ form.blat }}
+      {{ form.llon }}
+      {{ form.rlon }}
+
+   {# minDate / maxDate feed the jQuery datepicker min/max – not user inputs #}
+      <input type="hidden" id="minDate" value="{{ subset.date_start }}">
+      <input type="hidden" id="maxDate" value="{{ subset.date_end }}">
 
 <!-- Temporal range selection -->
 <div class="py-2" id="dateSelect">

--- a/datasets/templates/datasets/custom-subset-page-d351000.html
+++ b/datasets/templates/datasets/custom-subset-page-d351000.html
@@ -103,6 +103,7 @@
       <i class="fa-solid fa-arrow-up-right-from-square"></i>
       to search for station information in the WMO Oscar/Surface WIGOS metadata repository.
    </div>
+   {{ form.stationIDs.label_tag }}
    {{ form.stationIDs }}
 </div>
 

--- a/datasets/templates/datasets/custom-subset-page-d351000.html
+++ b/datasets/templates/datasets/custom-subset-page-d351000.html
@@ -103,7 +103,7 @@
       <i class="fa-solid fa-arrow-up-right-from-square"></i>
       to search for station information in the WMO Oscar/Surface WIGOS metadata repository.
    </div>
-   {{ form.stationIDs.label_tag }}
+   <label class="form-label" for="stationIDs">{{ form.stationIDs.label }}</label>
    {{ form.stationIDs }}
 </div>
 

--- a/datasets/templates/datasets/custom-subset-page-d351000.html
+++ b/datasets/templates/datasets/custom-subset-page-d351000.html
@@ -103,7 +103,7 @@
       <i class="fa-solid fa-arrow-up-right-from-square"></i>
       to search for station information in the WMO Oscar/Surface WIGOS metadata repository.
    </div>
-   {{ form.station0 }}
+   {{ form.stationIDs }}
 </div>
 
 <hr class="my-1">

--- a/datasets/templates/datasets/custom-subset-page-d351000.html
+++ b/datasets/templates/datasets/custom-subset-page-d351000.html
@@ -103,8 +103,7 @@
       <i class="fa-solid fa-arrow-up-right-from-square"></i>
       to search for station information in the WMO Oscar/Surface WIGOS metadata repository.
    </div>
-   <label for="station0">Station IDs (comma separated): </label>
-   <textarea class="form-control" name="station0" id="station0" rows="4"></textarea>
+   {{ form.station0 }}
 </div>
 
 <hr class="my-1">

--- a/datasets/templates/datasets/custom-subset-page-d461000.html
+++ b/datasets/templates/datasets/custom-subset-page-d461000.html
@@ -102,6 +102,7 @@
       <i class="fa-solid fa-arrow-up-right-from-square"></i>
       to search for station information in the WMO Oscar/Surface WIGOS metadata repository.
    </div>
+   {{ form.stationIDs.label_tag }}
    {{ form.stationIDs }}
 </div>
 

--- a/datasets/templates/datasets/custom-subset-page-d461000.html
+++ b/datasets/templates/datasets/custom-subset-page-d461000.html
@@ -102,7 +102,7 @@
       <i class="fa-solid fa-arrow-up-right-from-square"></i>
       to search for station information in the WMO Oscar/Surface WIGOS metadata repository.
    </div>
-   {{ form.stationIDs.label_tag }}
+   <label class="form-label" for="stationIDs">{{ form.stationIDs.label }}</label>
    {{ form.stationIDs }}
 </div>
 

--- a/datasets/templates/datasets/custom-subset-page-d461000.html
+++ b/datasets/templates/datasets/custom-subset-page-d461000.html
@@ -102,7 +102,7 @@
       <i class="fa-solid fa-arrow-up-right-from-square"></i>
       to search for station information in the WMO Oscar/Surface WIGOS metadata repository.
    </div>
-   {{ form.station0 }}
+   {{ form.stationIDs }}
 </div>
 
 <hr class="my-1">

--- a/datasets/templates/datasets/custom-subset-page-d461000.html
+++ b/datasets/templates/datasets/custom-subset-page-d461000.html
@@ -102,8 +102,7 @@
       <i class="fa-solid fa-arrow-up-right-from-square"></i>
       to search for station information in the WMO Oscar/Surface WIGOS metadata repository.
    </div>
-   <label for="station0">Station IDs (comma separated): </label>
-   <textarea class="form-control" name="station0" id="station0" rows="4"></textarea>
+   {{ form.station0 }}
 </div>
 
 <hr class="my-1">

--- a/datasets/views.py
+++ b/datasets/views.py
@@ -37,7 +37,7 @@ from globus.views import get_guest_collection_url
 from gdexwebserver.utils import make_tempdir, remove_tempdir
 from dashboard.utils import get_user_email, is_internal_user
 
-from .forms import DatasetRequestForm, BUFRSubsetForm
+from .forms import DatasetRequestForm, BUFRSubsetForm, ISPDSubsetForm
 from rda_python_dsrqst.PgRDARqst import rda_request
 
 import logging
@@ -706,22 +706,28 @@ def custom_subset(request, dsid):
         ctx.update({'page': d})
         logger.info("Added dataset description context to custom subset page for dataset {}".format(dsid))
     
+    initial_form_data = {
+        'dsid': dsid,
+        'gindex': subset_context.get('gindex', 1),
+        'rtype': 'S',
+        'startDate': subset_context.get('date_start', ''),
+        'endDate': subset_context.get('date_end', ''),
+        'compr': 'gz',
+    }
     if dsid in ['d351000', 'd461000']:
         ctx['form'] = BUFRSubsetForm(
             auto_id='%s',
             dsid=dsid,
-            initial={
-                'dsid':      dsid,
-                'gindex':    subset_context.get('gindex', 1),
-                'rtype':     'S',
-                'startDate': subset_context.get('date_start', ''),
-                'endDate':   subset_context.get('date_end', ''),
-                'compr':     'gz',
-            },
+            initial=initial_form_data,
+        )
+    if dsid == 'd132002':
+        ctx['form'] = ISPDSubsetForm(
+            auto_id='%s',
+            dsid=dsid,
+            initial=initial_form_data,
         )
 
     return render(request, template, ctx)
-
 
 def example_view(request, dsid):
     """Displays page to get code examples."""


### PR DESCRIPTION
This pull request updates the way station IDs are handled in the dataset forms and related frontend code, improving consistency and allowing for both 5- and 6-digit WMO numbers. The main changes include renaming the field, updating validation, and ensuring all references use the new field name.

**Form and Validation Updates:**

* Renamed the form field from `station0` to `stationIDs` in `datasets/forms.py`, and updated validation to accept both 5- and 6-digit WMO numbers. The label and widget attributes were also updated for clarity and consistency.

**Frontend and Template Consistency:**

* Updated all references in the frontend JavaScript (`datasets/static/datasets/js/BUFR_subset.js`) to use the new `stationIDs` field instead of `station0`.
* Modified the templates `custom-subset-page-d351000.html` and `custom-subset-page-d461000.html` to use the new `stationIDs` form field, replacing the previous manual label and textarea with the Django form field rendering. [[1]](diffhunk://#diff-6c13d8dfb0e352a600091c031b884fd8fa9540ecd2eab8bf492702160f04ebdcL106-R106) [[2]](diffhunk://#diff-634268f0f67d1d1ae3db568a59435fc8ee695a1c38da5a6c364c335dfd826a62L105-R105)This pull request updates the station ID input field in the custom subset forms to use the Django form rendering system and improves form validation and labeling. The most important changes are:

**Form rendering and validation improvements:**

* The station ID input in both `custom-subset-page-d351000.html` and `custom-subset-page-d461000.html` is now rendered using `{{ form.station0 }}` instead of a manually coded `<textarea>`, ensuring consistent rendering and validation. [[1]](diffhunk://#diff-6c13d8dfb0e352a600091c031b884fd8fa9540ecd2eab8bf492702160f04ebdcL106-R106) [[2]](diffhunk://#diff-634268f0f67d1d1ae3db568a59435fc8ee695a1c38da5a6c364c335dfd826a62L105-R105)
* The `station0` field in `datasets/forms.py` now enforces a minimum length of 5 characters, updates the label to "Station IDs (comma-separated)", and explicitly sets the field's `id` attribute for better accessibility and consistency.