### PR TITLE
datasets - don't display empty groups

### DIFF
--- a/api/common.py
+++ b/api/common.py
@@ -1308,7 +1308,7 @@ def get_child_groups(dsid, gindex):
     con,cur = init_connection_new()
     columns = ('grpid','gindex','inote','mnote','dwebcnt','webcnt','title','webpath')
     columns_str = ','.join(columns)
-    query = 'select '+columns_str+' from dsgroup where dsid=%s and pindex=%s order by gindex asc'
+    query = 'select '+columns_str+' from dsgroup where dsid=%s and pindex=%s and (dwebcnt>0 or webcnt>0) order by gindex asc'
     cur.execute(query,(dsid,gindex))
     data = cur.fetchall()
     close_connection(con,cur)

--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v29767645986
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v29769782101
     port: 8080
     requests:
       memory: 4Gi

--- a/app-chart/values.yaml.tcram
+++ b/app-chart/values.yaml.tcram
@@ -9,7 +9,7 @@ webapp:
     fqdnAPI: api.tcram.k8s.ucar.edu
     secretName: incommon-cert-tcram-gdex-webserver
   container: 
-    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v29534790082
+    image: hub.k8s.ucar.edu/tcram-gdex/gdex-web-portal:v29767645986
     port: 8080
     requests:
       memory: 4Gi

--- a/datasets/templates/datasets/filelist-subgroup-table.html
+++ b/datasets/templates/datasets/filelist-subgroup-table.html
@@ -18,6 +18,7 @@
         </thead>
         <tbody>
             {% for group in data.groups %}
+            {% if group.total_file_count > 0 %}
             <tr>
                 <td>
                     {% if not data.groups.0.gindex|add:"0" < 0  %} 
@@ -32,6 +33,7 @@
                     {{ group.rows|length }}
                 </td>
             </tr>
+            {% endif %}
             {% endfor %}
         </tbody>
       </table>

--- a/datasets/templates/datasets/filelist.html
+++ b/datasets/templates/datasets/filelist.html
@@ -44,7 +44,7 @@
 {% else %}
     {# Standard filelist table display #}
     {% for group in data.groups %}
-        {% if group.title and group.title != data.title %}
+        {% if group.title and group.title != data.title and group.total_file_count > 0 %}
             {# Show group title if the group has one and it differs from the page title #}
             <h3 id='{{group.group_id|slugify}}'>
                 {{group.title}}


### PR DESCRIPTION
This pull request updates the rendering logic for group and subgroup tables in the `datasets` templates to ensure that only groups with files are displayed. This helps clean up the UI by hiding empty groups and their headers.

Display logic improvements:

* [`datasets/templates/datasets/filelist-subgroup-table.html`](diffhunk://#diff-77a17c62e1b446e9af189ca8f8a7d5aa7fa5539b4327b294eef200b611d83f17R21): Updated the template to only render subgroup rows if `group.total_file_count > 0`, preventing empty groups from being shown in the subgroup summary table. [[1]](diffhunk://#diff-77a17c62e1b446e9af189ca8f8a7d5aa7fa5539b4327b294eef200b611d83f17R21) [[2]](diffhunk://#diff-77a17c62e1b446e9af189ca8f8a7d5aa7fa5539b4327b294eef200b611d83f17R36)
* [`datasets/templates/datasets/filelist.html`](diffhunk://#diff-23f127f9a1650c8b7e8ae4d93e68c3a70458dbb576d1d8af98e1e0b005f66629L47-R47): Modified the group title display condition to also require `group.total_file_count > 0`, so group titles are only shown for groups that contain files.